### PR TITLE
feat: register vendor con arquitectura hexagonal + evento 401 con aut…

### DIFF
--- a/Frontend/src/application/use-cases/RegisterVendorUseCase.ts
+++ b/Frontend/src/application/use-cases/RegisterVendorUseCase.ts
@@ -1,0 +1,10 @@
+import type { IAuthRepository } from "../../domain/interfaces/IAuthRepository";
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
+
+export class RegisterVendorUseCase {
+  constructor(private readonly authRepository: IAuthRepository) {}
+
+  async execute(data: RegisterVendorRequest): Promise<VendorRegisterResponse> {
+    return this.authRepository.registerVendor(data);
+  }
+}

--- a/Frontend/src/domain/interfaces/IAuthRepository.ts
+++ b/Frontend/src/domain/interfaces/IAuthRepository.ts
@@ -1,12 +1,11 @@
 
 import type { AuthResponse, LoginRequest, RegisterRequest, RegisterDeliveryRequest } from "../types/auth.types";
-
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../types/vendor.types";
 
 export interface IAuthRepository {
   login(credentials: LoginRequest): Promise<AuthResponse>;
   register(data: RegisterRequest): Promise<AuthResponse>;
-  logout(): Promise<void>;
-  getCurrentUser(): Promise<void>;
   registerDelivery(data: RegisterDeliveryRequest): Promise<AuthResponse>;
-
+  registerVendor(data: RegisterVendorRequest): Promise<VendorRegisterResponse>;
+  logout(): Promise<void>;
 }

--- a/Frontend/src/infrastructure/api/authApi.ts
+++ b/Frontend/src/infrastructure/api/authApi.ts
@@ -1,5 +1,7 @@
 import axios from "axios";
 import type { RegisterDeliveryRequest, RegisterRequest } from "../../domain/types/auth.types";
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
+import { authLocalStorage } from "../persistence/authLocalStorage";
 
 const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
@@ -12,7 +14,7 @@ export const authApi = axios.create({
 
 // Interceptor para agregar token en cada request
 authApi.interceptors.request.use((config) => {
-  const token = localStorage.getItem("auth_token");
+  const token = authLocalStorage.getToken();
 
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
@@ -26,10 +28,8 @@ authApi.interceptors.response.use(
   (response) => response,
   (error) => {
     if (error.response?.status === 401) {
-      // Token expirado o inválido
-      localStorage.removeItem("auth_token");
-      localStorage.removeItem("auth_user");
-      window.location.href = "/";
+      authLocalStorage.clear();
+      window.dispatchEvent(new CustomEvent('auth:unauthorized'));
     }
 
     return Promise.reject(error);
@@ -55,5 +55,10 @@ export const logoutApi = async () => {
 
 export const registerDeliveryApi = async (data: RegisterDeliveryRequest) => {
   const response = await authApi.post("/auth/register-courier", data);
+  return response.data;
+};
+
+export const registerVendorApi = async (data: RegisterVendorRequest): Promise<VendorRegisterResponse> => {
+  const response = await authApi.post<VendorRegisterResponse>("/auth/register-vendor", data);
   return response.data;
 };

--- a/Frontend/src/infrastructure/api/vendorApi.ts
+++ b/Frontend/src/infrastructure/api/vendorApi.ts
@@ -1,11 +1,11 @@
 import axios from "axios";
 import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
 
-const API_URL = "http://localhost:3000/auth/register-vendor";
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
 
 export const vendorApi = {
   register: async (data: RegisterVendorRequest): Promise<VendorRegisterResponse> => {
-    const response = await axios.post<VendorRegisterResponse>(API_URL, data);
+    const response = await axios.post<VendorRegisterResponse>(`${API_URL}/auth/register-vendor`, data);
     return response.data;
   },
 };

--- a/Frontend/src/infrastructure/repositories/AuthRepositoryImpl.ts
+++ b/Frontend/src/infrastructure/repositories/AuthRepositoryImpl.ts
@@ -1,8 +1,8 @@
 import type { IAuthRepository } from "../../domain/interfaces/IAuthRepository";
 import type { AuthResponse, LoginRequest, RegisterRequest, RegisterDeliveryRequest } from "../../domain/types/auth.types";
-import { loginApi, registerApi, logoutApi } from "../api/authApi";
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
+import { loginApi, registerApi, registerDeliveryApi, registerVendorApi } from "../api/authApi";
 import { authLocalStorage } from "../persistence/authLocalStorage";
-import { registerDeliveryApi } from "../api/authApi";
 
 export class AuthRepositoryImpl implements IAuthRepository {
   async login(credentials: LoginRequest): Promise<AuthResponse> {
@@ -58,16 +58,11 @@ export class AuthRepositoryImpl implements IAuthRepository {
     }
   }
 
-  async logout(): Promise<void> {
-    try {
-      await logoutApi();
-    } finally {
-      // Limpiar localStorage sin importar si la llamada falló
-      authLocalStorage.clear();
-    }
+  async registerVendor(data: RegisterVendorRequest): Promise<VendorRegisterResponse> {
+    return registerVendorApi(data);
   }
 
-  async getCurrentUser(): Promise<void> {
-    // Implementar si es necesario
+  async logout(): Promise<void> {
+    authLocalStorage.clear();
   }
 }

--- a/Frontend/src/ui/context/AuthContext.ts
+++ b/Frontend/src/ui/context/AuthContext.ts
@@ -5,12 +5,14 @@
 
 import { createContext } from "react";
 import type { AuthState, RegisterDeliveryRequest, RegisterRequest } from "../../domain/types/auth.types";
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
 import type { VerifyDocumentRequest, VerificationResult } from "../../domain/types/verification.types";
 
 export interface AuthContextType extends AuthState {
   login: (email: string, password: string) => Promise<void>;
   register: (data: RegisterRequest) => Promise<void>;
   registerDelivery: (data: RegisterDeliveryRequest) => Promise<void>;
+  registerVendor: (data: RegisterVendorRequest) => Promise<VendorRegisterResponse>;
   verifyDocument: (images: File[], data: VerifyDocumentRequest) => Promise<VerificationResult>;
 
   logout: () => Promise<void>;

--- a/Frontend/src/ui/context/AuthProvider.tsx
+++ b/Frontend/src/ui/context/AuthProvider.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useMemo,
+import { useState, useCallback, useMemo, useEffect,
    type ReactNode } from "react";
 import { AuthContext, type AuthContextType } from "./AuthContext";
 import type { AuthState } from "../../domain/types/auth.types";
@@ -8,9 +8,11 @@ import { LogoutUseCase } from "../../application/use-cases/LogoutUseCase";
 import { AuthRepositoryImpl } from "../../infrastructure/repositories/AuthRepositoryImpl";
 import { authLocalStorage } from "../../infrastructure/persistence/authLocalStorage";
 import { RegisterDeliveryUseCase } from "../../application/use-cases/RegisterDeliveryUseCase";
+import { RegisterVendorUseCase } from "../../application/use-cases/RegisterVendorUseCase";
 import { VerifyDocumentUseCase } from "../../application/use-cases/VerifyDocumentUseCase";
 import { VerificationRepositoryImpl } from "../../infrastructure/repositories/VerificationRepositoryImpl";
 import type { RegisterDeliveryRequest, RegisterRequest } from "../../domain/types/auth.types";
+import type { RegisterVendorRequest, VendorRegisterResponse } from "../../domain/types/vendor.types";
 import type { VerifyDocumentRequest } from "../../domain/types/verification.types";
 
 interface AuthProviderProps {
@@ -29,6 +31,11 @@ const registerDeliveryUseCase = useMemo(
   [authRepository]
 );
 
+const registerVendorUseCase = useMemo(
+  () => new RegisterVendorUseCase(authRepository),
+  [authRepository]
+);
+
 const verificationRepository = useMemo(() => new VerificationRepositoryImpl(), []);
 const verifyDocumentUseCase = useMemo(
   () => new VerifyDocumentUseCase(verificationRepository),
@@ -44,6 +51,21 @@ const [state, setState] = useState<AuthState>({
   error: null,
 });
 
+
+  // Escuchar evento de no autorizado (disparado por el interceptor 401 de axios)
+  useEffect(() => {
+    const handleUnauthorized = () => {
+      setState({
+        user: null,
+        token: null,
+        isAuthenticated: false,
+        isLoading: false,
+        error: null,
+      });
+    };
+    window.addEventListener('auth:unauthorized', handleUnauthorized);
+    return () => window.removeEventListener('auth:unauthorized', handleUnauthorized);
+  }, []);
 
   // LOGIN
   const login = useCallback(async (email: string, password: string) => {
@@ -140,6 +162,39 @@ const [state, setState] = useState<AuthState>({
     [registerDeliveryUseCase]
   );
 
+  // REGISTER VENDOR
+  const registerVendor = useCallback(
+    async (data: RegisterVendorRequest): Promise<VendorRegisterResponse> => {
+      setState((prev) => ({ ...prev, isLoading: true, error: null }));
+
+      try {
+        const response = await registerVendorUseCase.execute(data);
+
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: null,
+        }));
+
+        return response;
+      } catch (error) {
+        const errorMessage =
+          error instanceof Error
+            ? error.message
+            : "Error al registrar negocio";
+
+        setState((prev) => ({
+          ...prev,
+          isLoading: false,
+          error: errorMessage,
+        }));
+
+        throw error;
+      }
+    },
+    [registerVendorUseCase]
+  );
+
   // LOGOUT
   const logout = useCallback(async () => {
     setState((prev) => ({ ...prev, isLoading: true }));
@@ -180,6 +235,7 @@ const [state, setState] = useState<AuthState>({
     register,
     logout,
     registerDelivery,
+    registerVendor,
     verifyDocument,
   };
 

--- a/Frontend/src/ui/pages/VendorRegister/VendorRegister.tsx
+++ b/Frontend/src/ui/pages/VendorRegister/VendorRegister.tsx
@@ -4,8 +4,7 @@ import { useState, useRef } from "react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
-import { vendorApi } from "../../../infrastructure/api/vendorApi";
-import { verifyDocumentApi } from "../../../infrastructure/api/verificationApi";
+import { useAuth } from "../../context/useAuth";
 import type { RegisterVendorRequest } from "../../../domain/types/vendor.types";
 
 const schema = z.object({
@@ -42,6 +41,7 @@ const stepTitles: Record<number, string> = {
 
 const VendorRegister = () => {
   const navigate = useNavigate();
+  const { verifyDocument: verifyDocumentApi, registerVendor, error: contextError } = useAuth();
   const [step, setStep] = useState(1);
   const [isLoading, setIsLoading] = useState(false);
   const [apiError, setApiError] = useState("");
@@ -162,7 +162,7 @@ const VendorRegister = () => {
         nit: data.nit,
         document_url: data.document_url,
       };
-      await vendorApi.register(payload);
+      await registerVendor(payload as RegisterVendorRequest);
       setShowSuccess(true);
     } catch (error: any) {
       if (error.response) {
@@ -224,7 +224,7 @@ const VendorRegister = () => {
 
           <p className="step-title">{stepTitle}</p>
 
-          {apiError && <div className="api-error">{apiError}</div>}
+          {(apiError || contextError) && <div className="api-error">{apiError || contextError}</div>}
 
           <form onSubmit={handleSubmit(onSubmit)}>
             {step === 1 && (


### PR DESCRIPTION
### Descripción:
- Creado RegisterVendorUseCase en capa de aplicación
- IAuthRepository: agregado registerVendor, eliminado getCurrentUser (YAGNI)
- authApi.ts: agregado registerVendorApi; interceptores ahora usan authLocalStorage
  y evento auth:unauthorized en vez de hard redirect
- AuthRepositoryImpl: implementado registerVendor; logout simplificado
- vendorApi.ts: URL parametrizada con VITE_API_URL
- AuthContext: expuesto registerVendor en AuthContextType
- AuthProvider: cableado registerVendorUseCase + efecto para auth:unauthorized
- VendorRegister.tsx: eliminados imports de infraestructura, ahora usa useAuth()
- Corregido bug de shadowing en verifyDocument que causaba llamada recursiva
- tsc --noEmit exitoso


Fixes #40 