### PR TITLE
Implementacion de SuperAdmin para Backups Manuales

### DIFF
--- a/backend/src/backup/infrastructure/controllers/backup.controller.ts
+++ b/backend/src/backup/infrastructure/controllers/backup.controller.ts
@@ -2,7 +2,7 @@ import { Controller, Get, Post, UseGuards } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiBearerAuth } from '@nestjs/swagger';
 import { JwtAuthGuard } from 'src/auth/infrastructure/guards/jwt-auth.guard';
 import { RolesGuard } from 'src/auth/infrastructure/guards/roles.guard';
-import { Roles, UserRole } from 'src/auth/infrastructure/decorators/roles.decorator';
+import { MinRole, UserRole } from 'src/auth/infrastructure/decorators/roles.decorator';
 import { RunBackupUseCase } from '../../application/use-cases/run-backup.use-case';
 import { ListBackupsUseCase } from '../../application/use-cases/list-backups.use-case';
 
@@ -17,14 +17,14 @@ export class BackupController {
   ) {}
 
   @Post()
-  @Roles(UserRole.ADMIN)
+  @MinRole(UserRole.ADMIN) 
   @ApiOperation({ summary: 'Disparar backup manual' })
   run() {
     return this.runBackup.execute();
   }
 
   @Get()
-  @Roles(UserRole.ADMIN)
+  @MinRole(UserRole.ADMIN) 
   @ApiOperation({ summary: 'Listar backups disponibles' })
   list() {
     return this.listBackups.execute();


### PR DESCRIPTION
### Descripcion
Se corrige el control de acceso en los endpoints de backup reemplazando @Roles(UserRole.ADMIN) por @MinRole(UserRole.ADMIN), garantizando que tanto ADMIN como SUPERADMIN puedan disparar backups manuales y consultar los backups disponibles, en coherencia con la jerarquía de roles implementada en el sistema.

### Fixes #67 