### PR TITLE
Correccion de error en carga de imagen en categoria

### DIFF
--- a/backend/src/storage/application/use-cases/upload-image.use-case.ts
+++ b/backend/src/storage/application/use-cases/upload-image.use-case.ts
@@ -1,6 +1,5 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { IStorageRepository } from '../../domain/repositories/storage.repository.interface';
-import { UploadResult } from '../../domain/interfaces/upload-result.interface';
 import { randomUUID } from 'crypto';
 
 @Injectable()
@@ -10,8 +9,9 @@ export class UploadImageUseCase {
     private readonly storageRepo: IStorageRepository,
   ) {}
 
-  async execute(file: Express.Multer.File, folder: string): Promise<UploadResult> {
+  async execute(file: Express.Multer.File, folder: string) {
     const filename = `${Date.now()}-${randomUUID()}`;
-    return this.storageRepo.uploadImage(file.buffer, folder, filename);
+    const result = await this.storageRepo.uploadImage(file.buffer, folder, filename);
+    return { image_url: result.secure_url, public_id: result.public_id };
   }
 }


### PR DESCRIPTION
### Descripcion

Se ajustó el caso de uso UploadImageUseCase en el backend para que devuelva { image_url, public_id } en lugar del objeto completo de Cloudinary. Esto es consistente con lo que ya se hacía para imágenes de producto, donde el mapeo de secure_url a image_url ya existía.

### Fixes #78 

### Foto
<img width="289" height="260" alt="image" src="https://github.com/user-attachments/assets/744c3cdf-f59d-4e45-8322-389006cacb48" />
