### PR TITLE
Sistema de rastreo GPS en tiempo real de domiciliarios con Redis

### DIFF
--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -21,6 +21,7 @@
         "react-leaflet": "^4.2.1",
         "react-router-dom": "^7.14.2",
         "repomix": "^1.14.1",
+        "socket.io-client": "^4.8.3",
         "zod": "^4.3.6"
       },
       "devDependencies": {
@@ -55,13 +56,13 @@
       }
     },
     "node_modules/@babel/code-frame": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.0.tgz",
-      "integrity": "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.29.7.tgz",
+      "integrity": "sha512-Aup7aUOfpbAUg2ROOJN6Iw5f9DMBlzu0mIkm/malLQFN/YQgO48wCj0Kxa3sEHJvPVFg7siR+qRInwXd2qhQKw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-validator-identifier": "^7.28.5",
+        "@babel/helper-validator-identifier": "^7.29.7",
         "js-tokens": "^4.0.0",
         "picocolors": "^1.1.1"
       },
@@ -70,9 +71,9 @@
       }
     },
     "node_modules/@babel/compat-data": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.0.tgz",
-      "integrity": "sha512-T1NCJqT/j9+cn8fvkt7jtwbLBfLC/1y1c7NtCeXFRgzGTsafi68MRv8yzkYSapBnFA6L3U2VSc02ciDzoAJhJg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.29.7.tgz",
+      "integrity": "sha512-locTkQyKvwIEgBzVrn8693ebc97F2U8ZHjbXwDXJ5Fn2TCpNwTlKcaKLkdHop5c/icOFE7qt7Q9JC5hnKNa6Gg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -80,21 +81,21 @@
       }
     },
     "node_modules/@babel/core": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.0.tgz",
-      "integrity": "sha512-CGOfOJqWjg2qW/Mb6zNsDm+u5vFQ8DxXfbM09z69p5Z6+mE1ikP2jUXw+j42Pf1XTYED2Rni5f95npYeuwMDQA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.29.7.tgz",
+      "integrity": "sha512-RgHBCvtjbOK2gXSNBNIkNoEc9qoVEtau3hj8gEqKQuL3HZAibKarWFEI3Lfm6EYKkLalOh8eSrj9b+ch9H/VBA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-compilation-targets": "^7.28.6",
-        "@babel/helper-module-transforms": "^7.28.6",
-        "@babel/helpers": "^7.28.6",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/traverse": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-compilation-targets": "^7.29.7",
+        "@babel/helper-module-transforms": "^7.29.7",
+        "@babel/helpers": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/remapping": "^2.3.5",
         "convert-source-map": "^2.0.0",
         "debug": "^4.1.0",
@@ -111,14 +112,14 @@
       }
     },
     "node_modules/@babel/generator": {
-      "version": "7.29.1",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.1.tgz",
-      "integrity": "sha512-qsaF+9Qcm2Qv8SRIMMscAvG4O3lJ0F1GuMo5HR/Bp02LopNgnZBC/EkbevHFeGs4ls/oPz9v+Bsmzbkbe+0dUw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.29.7.tgz",
+      "integrity": "sha512-DkXD5OJQaAQIdZ1bt3UZdEnHAn9Imd3IVBdX03UFe+ony9Ojw5pzr9YVKGDY1jt+Gcn/FnGkNf8r+Vj5NOJWtQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/parser": "^7.29.0",
-        "@babel/types": "^7.29.0",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "@jridgewell/gen-mapping": "^0.3.12",
         "@jridgewell/trace-mapping": "^0.3.28",
         "jsesc": "^3.0.2"
@@ -128,14 +129,14 @@
       }
     },
     "node_modules/@babel/helper-compilation-targets": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.28.6.tgz",
-      "integrity": "sha512-JYtls3hqi15fcx5GaSNL7SCTJ2MNmjrkHXg4FSpOA/grxK8KwyZ5bubHsCq8FXCkua6xhuaaBit+3b7+VZRfcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.29.7.tgz",
+      "integrity": "sha512-wem6WaBj4NaVYVdNhLPPVacES6ZJ+KBBfSkTMD3YZxbP3rm3Di85tJU5ljaUNhaOynt+Aj0xruhYuzQBt8n71g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/compat-data": "^7.28.6",
-        "@babel/helper-validator-option": "^7.27.1",
+        "@babel/compat-data": "^7.29.7",
+        "@babel/helper-validator-option": "^7.29.7",
         "browserslist": "^4.24.0",
         "lru-cache": "^5.1.1",
         "semver": "^6.3.1"
@@ -145,9 +146,9 @@
       }
     },
     "node_modules/@babel/helper-globals": {
-      "version": "7.28.0",
-      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.28.0.tgz",
-      "integrity": "sha512-+W6cISkXFa1jXsDEdYA8HeevQT/FULhxzR99pxphltZcVaugps53THCeiWA8SguxxpSp3gKPiuYfSWopkLQ4hw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-globals/-/helper-globals-7.29.7.tgz",
+      "integrity": "sha512-3nQVUAtvkKH9zahfWgw96Jc/uFOmjACE1kQz82E2lqWmHBgjzbNlsC22nuQTfahmWeQtTq5nQ/4Nnd2A1wj4zA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -155,29 +156,29 @@
       }
     },
     "node_modules/@babel/helper-module-imports": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.28.6.tgz",
-      "integrity": "sha512-l5XkZK7r7wa9LucGw9LwZyyCUscb4x37JWTPz7swwFE/0FMQAGpiWUZn8u9DzkSBWEcK25jmvubfpw2dnAMdbw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.29.7.tgz",
+      "integrity": "sha512-ejHwrQQYcm9xnTivShn2IDOlIzInN34AXskvq9QicvCtEzq1Vzclu/tKF8Jq1Cg8JG2GL6/EmjgsCT7lXepE3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/traverse": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/traverse": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/helper-module-transforms": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.28.6.tgz",
-      "integrity": "sha512-67oXFAYr2cDLDVGLXTEABjdBJZ6drElUSI7WKp70NrpyISso3plG9SAGEF6y7zbha/wOzUByWWTJvEDVNIUGcA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.29.7.tgz",
+      "integrity": "sha512-UPUVSyXbOh627KiCIGQSgwWzGeBKLkaJ9PJEdrngIwMSzxLR4jS4+f1f1jb7VzBbg8nFLaYotvVPFCTqdrmTAg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-module-imports": "^7.28.6",
-        "@babel/helper-validator-identifier": "^7.28.5",
-        "@babel/traverse": "^7.28.6"
+        "@babel/helper-module-imports": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7",
+        "@babel/traverse": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -187,9 +188,9 @@
       }
     },
     "node_modules/@babel/helper-string-parser": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.27.1.tgz",
-      "integrity": "sha512-qMlSxKbpRlAridDExk92nSobyDdpPijUq2DW6oDnUqd0iOGxmQjyqhMIihI9+zv4LPyZdRje2cavWPbCbWm3eA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -197,9 +198,9 @@
       }
     },
     "node_modules/@babel/helper-validator-identifier": {
-      "version": "7.28.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.28.5.tgz",
-      "integrity": "sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -207,9 +208,9 @@
       }
     },
     "node_modules/@babel/helper-validator-option": {
-      "version": "7.27.1",
-      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.27.1.tgz",
-      "integrity": "sha512-YvjJow9FxbhFFKDSuFnVCe2WxXk1zWc22fFePVNEaWJEu8IrZVlda6N0uHwzZrUM1il7NC9Mlp4MaJYbYd9JSg==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.29.7.tgz",
+      "integrity": "sha512-N9ZErrD+yW5geCDtBqnOoxmR8+tNKiGuxKlDpuJxfsqpa2dFcexaziGAE/qoHLiDDreVNMupxGmSoNlyvsA3gw==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -217,27 +218,27 @@
       }
     },
     "node_modules/@babel/helpers": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.2.tgz",
-      "integrity": "sha512-HoGuUs4sCZNezVEKdVcwqmZN8GoHirLUcLaYVNBK2J0DadGtdcqgr3BCbvH8+XUo4NGjNl3VOtSjEKNzqfFgKw==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.29.7.tgz",
+      "integrity": "sha512-1k2lAGRMfHTcwuNYcCNUmaUffmQv8KWMfh2iJUUeRlwlwH4FdNG7mfPI10NPfLHJFThE4Tyr4mv7kTNZOiPuBg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0"
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/parser": {
-      "version": "7.29.2",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.2.tgz",
-      "integrity": "sha512-4GgRzy/+fsBa72/RZVJmGKPmZu9Byn8o4MoLpmNe1m8ZfYnz5emHLQz3U4gLud6Zwl0RZIcgiLD7Uq7ySFuDLA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/types": "^7.29.0"
+        "@babel/types": "^7.29.7"
       },
       "bin": {
         "parser": "bin/babel-parser.js"
@@ -247,33 +248,33 @@
       }
     },
     "node_modules/@babel/template": {
-      "version": "7.28.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
-      "integrity": "sha512-YA6Ma2KsCdGb+WC6UpBVFJGXL58MDA6oyONbjyF/+5sBgxY/dwkhLogbMT2GXXyU84/IhRw/2D1Os1B/giz+BQ==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.29.7.tgz",
+      "integrity": "sha512-puq+Gf35oI24FeN11LkoUQFqv9uwNeWpxXZi/Ji3rRIoKAzKnxRaZ+Gkj0vKS9ZCiTESfng1N9LyOyXvo+m+Gg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.28.6",
-        "@babel/parser": "^7.28.6",
-        "@babel/types": "^7.28.6"
+        "@babel/code-frame": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/types": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
       }
     },
     "node_modules/@babel/traverse": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.0.tgz",
-      "integrity": "sha512-4HPiQr0X7+waHfyXPZpWPfWL/J7dcN1mx9gL6WdQVMbPnF3+ZhSMs8tCxN7oHddJE9fhNE7+lxdnlyemKfJRuA==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.29.7.tgz",
+      "integrity": "sha512-EhlfNQtZ+NK22w5BM61ciuiq1m58ed33Wr1Xan//ZRTy6hgjnwyCffRYwzsGXdASJSUJ1guZILsErh1eQcl+zw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/code-frame": "^7.29.0",
-        "@babel/generator": "^7.29.0",
-        "@babel/helper-globals": "^7.28.0",
-        "@babel/parser": "^7.29.0",
-        "@babel/template": "^7.28.6",
-        "@babel/types": "^7.29.0",
+        "@babel/code-frame": "^7.29.7",
+        "@babel/generator": "^7.29.7",
+        "@babel/helper-globals": "^7.29.7",
+        "@babel/parser": "^7.29.7",
+        "@babel/template": "^7.29.7",
+        "@babel/types": "^7.29.7",
         "debug": "^4.3.1"
       },
       "engines": {
@@ -281,14 +282,14 @@
       }
     },
     "node_modules/@babel/types": {
-      "version": "7.29.0",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.0.tgz",
-      "integrity": "sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==",
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@babel/helper-string-parser": "^7.27.1",
-        "@babel/helper-validator-identifier": "^7.28.5"
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
       },
       "engines": {
         "node": ">=6.9.0"
@@ -316,20 +317,20 @@
       }
     },
     "node_modules/@emnapi/core": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.9.1.tgz",
-      "integrity": "sha512-mukuNALVsoix/w1BJwFzwXBN/dHeejQtuVzcDsfOEsdpCumXb/E9j8w11h5S54tT1xhifGfbbSm/ICrObRb3KA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.10.0.tgz",
+      "integrity": "sha512-yq6OkJ4p82CAfPl0u9mQebQHKPJkY7WrIuk205cTYnYe+k2Z8YBh11FrbRG/H6ihirqcacOgl2BIO8oyMQLeXw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/wasi-threads": "1.2.0",
+        "@emnapi/wasi-threads": "1.2.1",
         "tslib": "^2.4.0"
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.1.tgz",
-      "integrity": "sha512-VYi5+ZVLhpgK4hQ0TAjiQiZ6ol0oe4mBx7mVv7IflsiEp0OWoVsp/+f9Vc1hOhE0TtkORVrI1GvzyreqpgWtkA==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -337,9 +338,9 @@
       }
     },
     "node_modules/@emnapi/wasi-threads": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.0.tgz",
-      "integrity": "sha512-N10dEJNSsUx41Z6pZsXU8FjPjpBEplgH24sfkmITrBED1/U2Esum9F3lfLrMjKHHjmi557zQn7kR9R+XWXu5Rg==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -516,9 +517,9 @@
       }
     },
     "node_modules/@hookform/resolvers": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.2.2.tgz",
-      "integrity": "sha512-A/IxlMLShx3KjV/HeTcTfaMxdwy690+L/ZADoeaTltLx+CVuzkeVIPuybK3jrRfw7YZnmdKsVVHAlEPIAEUNlA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@hookform/resolvers/-/resolvers-5.4.0.tgz",
+      "integrity": "sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==",
       "license": "MIT",
       "dependencies": {
         "@standard-schema/utils": "^0.3.0"
@@ -528,25 +529,39 @@
       }
     },
     "node_modules/@humanfs/core": {
-      "version": "0.19.1",
-      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
-      "integrity": "sha512-5DyQ4+1JEUzejeK1JGICcideyfUbGixgS9jNgex5nqkW+cY7WZhxBigmieN5Qnw9ZosSNVC9KQKyb+GUaGyKUA==",
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.2.tgz",
+      "integrity": "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA==",
       "dev": true,
       "license": "Apache-2.0",
+      "dependencies": {
+        "@humanfs/types": "^0.15.0"
+      },
       "engines": {
         "node": ">=18.18.0"
       }
     },
     "node_modules/@humanfs/node": {
-      "version": "0.16.7",
-      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.7.tgz",
-      "integrity": "sha512-/zUx+yOsIrG4Y43Eh2peDeKCxlRt/gET6aHfaKpuq267qXdYDFViVHfMaLyygZOnl0kGWxFIgsBy8QFuTLUXEQ==",
+      "version": "0.16.8",
+      "resolved": "https://registry.npmjs.org/@humanfs/node/-/node-0.16.8.tgz",
+      "integrity": "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@humanfs/core": "^0.19.1",
+        "@humanfs/core": "^0.19.2",
+        "@humanfs/types": "^0.15.0",
         "@humanwhocodes/retry": "^0.4.0"
       },
+      "engines": {
+        "node": ">=18.18.0"
+      }
+    },
+    "node_modules/@humanfs/types": {
+      "version": "0.15.0",
+      "resolved": "https://registry.npmjs.org/@humanfs/types/-/types-0.15.0.tgz",
+      "integrity": "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=18.18.0"
       }
@@ -699,13 +714,13 @@
       "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.2.tgz",
-      "integrity": "sha512-sNXv5oLJ7ob93xkZ1XnxisYhGYXfaG9f65/ZgYuAu3qt7b3NadcOEhLvx28hv31PgX8SZJRYrAIPQilQmFpLVw==",
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.5.tgz",
+      "integrity": "sha512-AWPoBRJ9tsnVhor4sjO7rkni+7p+2IAEFj6cx06UgP10jkQHqay/36uRV/bFkgrh18D9vb4cr8Q0Pthskgzy+Q==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@tybys/wasm-util": "^0.10.1"
+        "@tybys/wasm-util": "^0.10.2"
       },
       "funding": {
         "type": "github",
@@ -752,9 +767,9 @@
       }
     },
     "node_modules/@oxc-project/types": {
-      "version": "0.122.0",
-      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.122.0.tgz",
-      "integrity": "sha512-oLAl5kBpV4w69UtFZ9xqcmTi+GENWOcPF7FCrczTiBbmC0ibXxCwyvZGbO39rCVEuLGAZM84DH0pUIyyv/YJzA==",
+      "version": "0.133.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.133.0.tgz",
+      "integrity": "sha512-KzkdCd6Uxqnf6l3HOw1xfatAlUURA0g14cvBYFyJ5SaNOQbOUvBr9PKArcPcrNIeRsBdgcUzOGrhKveVpvOIGA==",
       "dev": true,
       "license": "MIT",
       "funding": {
@@ -788,9 +803,9 @@
       "license": "Unlicense"
     },
     "node_modules/@rolldown/binding-android-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-pv1y2Fv0JybcykuiiD3qBOBdz6RteYojRFY1d+b95WVuzx211CRh+ytI/+9iVyWQ6koTh5dawe4S/yRfOFjgaA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.3.tgz",
+      "integrity": "sha512-454rs7jHngixp/NMxd5srYD57OnzSlZ/eFTETjORQHLwJG1lRtmNOJcBerZlfu4GjKqeq8aCCIQrMdHyhI51Hw==",
       "cpu": [
         "arm64"
       ],
@@ -805,9 +820,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-cFYr6zTG/3PXXF3pUO+umXxt1wkRK/0AYT8lDwuqvRC+LuKYWSAQAQZjCWDQpAH172ZV6ieYrNnFzVVcnSflAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.3.tgz",
+      "integrity": "sha512-PcAhP+ynjURNyy8SKGl5DQP94aGuB/7JrXJb/t7P+hanXvQVMWzUvRRhBAcg/lNRadBhoUPqSoP4xw5tR/KBEA==",
       "cpu": [
         "arm64"
       ],
@@ -822,9 +837,9 @@
       }
     },
     "node_modules/@rolldown/binding-darwin-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ZCsYknnHzeXYps0lGBz8JrF37GpE9bFVefrlmDrAQhOEi4IOIlcoU1+FwHEtyXGx2VkYAvhu7dyBf75EJQffBw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.3.tgz",
+      "integrity": "sha512-9YpfeUvSE2RS7wysJ81uOZkXJz7f7Q55H2Gvp3VEw/EsahqDtrphrZ0EwDLK5vvKOzaCrBsjF8JmnMLcUt78Gg==",
       "cpu": [
         "x64"
       ],
@@ -839,9 +854,9 @@
       }
     },
     "node_modules/@rolldown/binding-freebsd-x64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-dMLeprcVsyJsKolRXyoTH3NL6qtsT0Y2xeuEA8WQJquWFXkEC4bcu1rLZZSnZRMtAqwtrF/Ib9Ddtpa/Gkge9Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.3.tgz",
+      "integrity": "sha512-yB1IlAsSNHncV6SCTL27/MVGR5htvQsoGxIv5KMGXALp+Ll1wYsn+x98M9MW7qa+NdSbvrrY7ANI4wLJ0n1e6g==",
       "cpu": [
         "x64"
       ],
@@ -856,9 +871,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0-rc.12.tgz",
-      "integrity": "sha512-YqWjAgGC/9M1lz3GR1r1rP79nMgo3mQiiA+Hfo+pvKFK1fAJ1bCi0ZQVh8noOqNacuY1qIcfyVfP6HoyBRZ85Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.3.tgz",
+      "integrity": "sha512-Yi30IVAAfLUCy2MseFjbB1jAMDl1VMCAas5StnYp8da9+CKvMd2H2cbEjWcw5NPaPqzvYkVIaF1nNUG+b7u/sw==",
       "cpu": [
         "arm"
       ],
@@ -873,9 +888,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-/I5AS4cIroLpslsmzXfwbe5OmWvSsrFuEw3mwvbQ1kDxJ822hFHIx+vsN/TAzNVyepI/j/GSzrtCIwQPeKCLIg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.3.tgz",
+      "integrity": "sha512-jsO7R8To+AdlYgUmN5sHSCZbfhtMBkO0WUx8iORQnPcMMdgr7qM2DQmMwgabs3GhNztdmoKkMKQFHD6DTMCIQw==",
       "cpu": [
         "arm64"
       ],
@@ -890,9 +905,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-arm64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-V6/wZztnBqlx5hJQqNWwFdxIKN0m38p8Jas+VoSfgH54HSj9tKTt1dZvG6JRHcjh6D7TvrJPWFGaY9UBVOaWPw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.3.tgz",
+      "integrity": "sha512-VWkUHwWriDciit80wleYwKILoR/KMvxh/IdwS/paX+ZgpuRpCrKLUdadJbc0NpBEiyhpYawsJ73j9aCvOH+f7Q==",
       "cpu": [
         "arm64"
       ],
@@ -907,9 +922,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-ppc64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-AP3E9BpcUYliZCxa3w5Kwj9OtEVDYK6sVoUzy4vTOJsjPOgdaJZKFmN4oOlX0Wp0RPV2ETfmIra9x1xuayFB7g==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.3.tgz",
+      "integrity": "sha512-5f1laC0SlIR0yDbFCd8acUhvJIag6N3zC5P7oUPN6wX0aOma+uKJ0wBDH5aq7I1PVI2ttTlhJwzwRIBnLiSGEg==",
       "cpu": [
         "ppc64"
       ],
@@ -924,9 +939,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-s390x-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-nWwpvUSPkoFmZo0kQazZYOrT7J5DGOJ/+QHHzjvNlooDZED8oH82Yg67HvehPPLAg5fUff7TfWFHQS8IV1n3og==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.3.tgz",
+      "integrity": "sha512-Iq4ko0r4XsgbrF/LunNgHtAGLRRVE2kXonAXQ/MV0mC6jQpMOhW1SvtZja2EhC/kd05++bP78dsqBeIQyYJ6Yg==",
       "cpu": [
         "s390x"
       ],
@@ -941,9 +956,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-gnu": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0-rc.12.tgz",
-      "integrity": "sha512-RNrafz5bcwRy+O9e6P8Z/OCAJW/A+qtBczIqVYwTs14pf4iV1/+eKEjdOUta93q2TsT/FI0XYDP3TCky38LMAg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.3.tgz",
+      "integrity": "sha512-B8m6tD5+/N5FeNQFbKlLA/2yVq9ycQP1SeedyEYYKWBNR3ZQbkvIUcNnDNM03lO1l5F2roiiFJGgvoLLyZXtSg==",
       "cpu": [
         "x64"
       ],
@@ -958,9 +973,9 @@
       }
     },
     "node_modules/@rolldown/binding-linux-x64-musl": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0-rc.12.tgz",
-      "integrity": "sha512-Jpw/0iwoKWx3LJ2rc1yjFrj+T7iHZn2JDg1Yny1ma0luviFS4mhAIcd1LFNxK3EYu3DHWCps0ydXQ5i/rrJ2ig==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.3.tgz",
+      "integrity": "sha512-pSdpdUJHkuCxun9LE7jvgUB9qsRgaiyNNCX7m/AvHTcq67AiT/Yhoxvw5zPfhrM8k/BfP8ce/hMOpthKDpEUow==",
       "cpu": [
         "x64"
       ],
@@ -975,9 +990,9 @@
       }
     },
     "node_modules/@rolldown/binding-openharmony-arm64": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0-rc.12.tgz",
-      "integrity": "sha512-vRugONE4yMfVn0+7lUKdKvN4D5YusEiPilaoO2sgUWpCvrncvWgPMzK00ZFFJuiPgLwgFNP5eSiUlv2tfc+lpA==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.3.tgz",
+      "integrity": "sha512-OXXS3RKJgX2uLwM+gYyuH5omcH8fL1LJs96pZGgtetVCahON57+d4SJHzTgZiOjxgGkSnpXpOsWuPDGAKAigEg==",
       "cpu": [
         "arm64"
       ],
@@ -992,9 +1007,9 @@
       }
     },
     "node_modules/@rolldown/binding-wasm32-wasi": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0-rc.12.tgz",
-      "integrity": "sha512-ykGiLr/6kkiHc0XnBfmFJuCjr5ZYKKofkx+chJWDjitX+KsJuAmrzWhwyOMSHzPhzOHOy7u9HlFoa5MoAOJ/Zg==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.3.tgz",
+      "integrity": "sha512-JTtb8BWFynicNSoPrehsCzBtOKjZ6jhMiPFEmOiuXg1Fl8dn2KHQob+GuPSGR0dryQa1PQJbzjF3dqO/whhjLg==",
       "cpu": [
         "wasm32"
       ],
@@ -1002,16 +1017,18 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@napi-rs/wasm-runtime": "^1.1.1"
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
       },
       "engines": {
-        "node": ">=14.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       }
     },
     "node_modules/@rolldown/binding-win32-arm64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-5eOND4duWkwx1AzCxadcOrNeighiLwMInEADT0YM7xeEOOFcovWZCq8dadXgcRHSf3Ulh1kFo/qvzoFiCLOL1Q==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.3.tgz",
+      "integrity": "sha512-gEdFFEN70A/jxb2svrWsN3aDL7OUtmvlOy+6fa2jxG8K0wQ1ZbdeLGnidov6Yu5/733dI5ySfzFlQ/cb0bSz1g==",
       "cpu": [
         "arm64"
       ],
@@ -1026,9 +1043,9 @@
       }
     },
     "node_modules/@rolldown/binding-win32-x64-msvc": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0-rc.12.tgz",
-      "integrity": "sha512-PyqoipaswDLAZtot351MLhrlrh6lcZPo2LSYE+VDxbVk24LVKAGOuE4hb8xZQmrPAuEtTZW8E6D2zc5EUZX4Lw==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.3.tgz",
+      "integrity": "sha512-eXB7CHuaQdqmJcc3koCNtNPmT/bj2gc999kUFgBxG8Ac0NdgXc4rkCHhqrgrhN3zddvvvrgzj1e90SuSfmyIXA==",
       "cpu": [
         "x64"
       ],
@@ -1043,9 +1060,9 @@
       }
     },
     "node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.7",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.7.tgz",
-      "integrity": "sha512-qujRfC8sFVInYSPPMLQByRh7zhwkGFS4+tyMQ83srV1qrxL4g8E2tyxVVyxd0+8QeBM1mIk9KbWxkegRr76XzA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.1.tgz",
+      "integrity": "sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==",
       "dev": true,
       "license": "MIT"
     },
@@ -1100,6 +1117,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/utils": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/utils/-/utils-0.3.0.tgz",
@@ -1107,47 +1130,47 @@
       "license": "MIT"
     },
     "node_modules/@tailwindcss/node": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.2.4.tgz",
-      "integrity": "sha512-Ai7+yQPxz3ddrDQzFfBKdHEVBg0w3Zl83jnjuwxnZOsnH9pGn93QHQtpU0p/8rYWxvbFZHneni6p1BSLK4DkGA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
+      "integrity": "sha512-aFb4gUhFOgdh9AXo4IzBEOzBkkAxm9VigwDJnMIYv3lcfXCJVesNfbEaBl4BNgVRyid92AmdviqwBUBRKSeY3g==",
       "license": "MIT",
       "dependencies": {
         "@jridgewell/remapping": "^2.3.5",
-        "enhanced-resolve": "^5.19.0",
+        "enhanced-resolve": "^5.21.0",
         "jiti": "^2.6.1",
         "lightningcss": "1.32.0",
         "magic-string": "^0.30.21",
         "source-map-js": "^1.2.1",
-        "tailwindcss": "4.2.4"
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.2.4.tgz",
-      "integrity": "sha512-9El/iI069DKDSXwTvB9J4BwdO5JhRrOweGaK25taBAvBXyXqJAX+Jqdvs8r8gKpsI/1m0LeJLyQYTf/WLrBT1Q==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.0.tgz",
+      "integrity": "sha512-F7HZGBeN9I0/AuuJS5PwcD8xayx5ri5GhjYUDBEVYUkexyA/giwbDNjRVrxSezE3T250OU2K/wp/ltWx3UOefg==",
       "license": "MIT",
       "engines": {
         "node": ">= 20"
       },
       "optionalDependencies": {
-        "@tailwindcss/oxide-android-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-arm64": "4.2.4",
-        "@tailwindcss/oxide-darwin-x64": "4.2.4",
-        "@tailwindcss/oxide-freebsd-x64": "4.2.4",
-        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-arm64-musl": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-gnu": "4.2.4",
-        "@tailwindcss/oxide-linux-x64-musl": "4.2.4",
-        "@tailwindcss/oxide-wasm32-wasi": "4.2.4",
-        "@tailwindcss/oxide-win32-arm64-msvc": "4.2.4",
-        "@tailwindcss/oxide-win32-x64-msvc": "4.2.4"
+        "@tailwindcss/oxide-android-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.0",
+        "@tailwindcss/oxide-darwin-x64": "4.3.0",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.0",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.0",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.0",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.0",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.0",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.0"
       }
     },
     "node_modules/@tailwindcss/oxide-android-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.2.4.tgz",
-      "integrity": "sha512-e7MOr1SAn9U8KlZzPi1ZXGZHeC5anY36qjNwmZv9pOJ8E4Q6jmD1vyEHkQFmNOIN7twGPEMXRHmitN4zCMN03g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.0.tgz",
+      "integrity": "sha512-TJPiq67tKlLuObP6RkwvVGDoxCMBVtDgKkLfa/uyj7/FyxvQwHS+UOnVrXXgbEsfUaMgiVvC4KbJnRr26ho4Ng==",
       "cpu": [
         "arm64"
       ],
@@ -1161,9 +1184,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-arm64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.2.4.tgz",
-      "integrity": "sha512-tSC/Kbqpz/5/o/C2sG7QvOxAKqyd10bq+ypZNf+9Fi2TvbVbv1zNpcEptcsU7DPROaSbVgUXmrzKhurFvo5eDg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.0.tgz",
+      "integrity": "sha512-oMN/WZRb+SO37BmUElEgeEWuU8E/HXRkiODxJxLe1UTHVXLrdVSgfaJV7pSlhRGMSOiXLuxTIjfsF3wYvz8cgQ==",
       "cpu": [
         "arm64"
       ],
@@ -1177,9 +1200,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-darwin-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.2.4.tgz",
-      "integrity": "sha512-yPyUXn3yO/ufR6+Kzv0t4fCg2qNr90jxXc5QqBpjlPNd0NqyDXcmQb/6weunH/MEDXW5dhyEi+agTDiqa3WsGg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.0.tgz",
+      "integrity": "sha512-N6CUmu4a6bKVADfw77p+iw6Yd9Q3OBhe0veaDX+QazfuVYlQsHfDgxBrsjQ/IW+zywL8mTrNd0SdJT/zgtvMdA==",
       "cpu": [
         "x64"
       ],
@@ -1193,9 +1216,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-freebsd-x64": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.2.4.tgz",
-      "integrity": "sha512-BoMIB4vMQtZsXdGLVc2z+P9DbETkiopogfWZKbWwM8b/1Vinbs4YcUwo+kM/KeLkX3Ygrf4/PsRndKaYhS8Eiw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.0.tgz",
+      "integrity": "sha512-zDL5hBkQdH5C6MpqbK3gQAgP80tsMwSI26vjOzjJtNCMUo0lFgOItzHKBIupOZNQxt3ouPH7RPhvNhiTfCe5CQ==",
       "cpu": [
         "x64"
       ],
@@ -1209,9 +1232,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.2.4.tgz",
-      "integrity": "sha512-7pIHBLTHYRAlS7V22JNuTh33yLH4VElwKtB3bwchK/UaKUPpQ0lPQiOWcbm4V3WP2I6fNIJ23vABIvoy2izdwA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.0.tgz",
+      "integrity": "sha512-R06HdNi7A7OEoMsf6d4tjZ71RCWnZQPHj2mnotSFURjNLdBC+cIgXQ7l81CqeoiQftjf6OOblxXMInMgN2VzMA==",
       "cpu": [
         "arm"
       ],
@@ -1225,9 +1248,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.2.4.tgz",
-      "integrity": "sha512-+E4wxJ0ZGOzSH325reXTWB48l42i93kQqMvDyz5gqfRzRZ7faNhnmvlV4EPGJU3QJM/3Ab5jhJ5pCRUsKn6OQw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.0.tgz",
+      "integrity": "sha512-qTJHELX8jetjhRQHCLilkVLmybpzNQAtaI/gaoVoidn/ufbNDbAo8KlK2J+yPoc8wQxvDxCmh/5lr8nC1+lTbg==",
       "cpu": [
         "arm64"
       ],
@@ -1241,9 +1264,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.2.4.tgz",
-      "integrity": "sha512-bBADEGAbo4ASnppIziaQJelekCxdMaxisrk+fB7Thit72IBnALp9K6ffA2G4ruj90G9XRS2VQ6q2bCKbfFV82g==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z6sukiQsngnWO+l39X4pPbiWT81IC+PLKF+PHxIlyZbGNb9MODfYlXEVlFvej5BOZInWX01kVyzeLvHsXhfczQ==",
       "cpu": [
         "arm64"
       ],
@@ -1257,9 +1280,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.2.4.tgz",
-      "integrity": "sha512-7Mx25E4WTfnht0TVRTyC00j3i0M+EeFe7wguMDTlX4mRxafznw0CA8WJkFjWYH5BlgELd1kSjuU2JiPnNZbJDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.0.tgz",
+      "integrity": "sha512-DRNdQRpSGzRGfARVuVkxvM8Q12nh19l4BF/G7zGA1oe+9wcC6saFBHTISrpIcKzhiXtSrlSrluCfvMuledoCTQ==",
       "cpu": [
         "x64"
       ],
@@ -1273,9 +1296,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-linux-x64-musl": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.2.4.tgz",
-      "integrity": "sha512-2wwJRF7nyhOR0hhHoChc04xngV3iS+akccHTGtz965FwF0up4b2lOdo6kI1EbDaEXKgvcrFBYcYQQ/rrnWFVfA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.0.tgz",
+      "integrity": "sha512-Z0IADbDo8bh6I7h2IQMx601AdXBLfFpEdUotft86evd/8ZPflZe9COPO8Q1vw+pfLWIUo9zN/JGZvwuAJqduqg==",
       "cpu": [
         "x64"
       ],
@@ -1289,9 +1312,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-wasm32-wasi": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.2.4.tgz",
-      "integrity": "sha512-FQsqApeor8Fo6gUEklzmaa9994orJZZDBAlQpK2Mq+DslRKFJeD6AjHpBQ0kZFQohVr8o85PPh8eOy86VlSCmw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.0.tgz",
+      "integrity": "sha512-HNZGOUxEmElksYR7S6sC5jTeNGpobAsy9u7Gu0AskJ8/20FR9GqebUyB+HBcU/ax6BHuiuJi+Oda4B+YX6H1yA==",
       "bundleDependencies": [
         "@napi-rs/wasm-runtime",
         "@emnapi/core",
@@ -1306,10 +1329,10 @@
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/core": "^1.8.1",
-        "@emnapi/runtime": "^1.8.1",
-        "@emnapi/wasi-threads": "^1.1.0",
-        "@napi-rs/wasm-runtime": "^1.1.1",
+        "@emnapi/core": "^1.10.0",
+        "@emnapi/runtime": "^1.10.0",
+        "@emnapi/wasi-threads": "^1.2.1",
+        "@napi-rs/wasm-runtime": "^1.1.4",
         "@tybys/wasm-util": "^0.10.1",
         "tslib": "^2.8.1"
       },
@@ -1318,9 +1341,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.2.4.tgz",
-      "integrity": "sha512-L9BXqxC4ToVgwMFqj3pmZRqyHEztulpUJzCxUtLjobMCzTPsGt1Fa9enKbOpY2iIyVtaHNeNvAK8ERP/64sqGQ==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Pe+RPVTi1T+qymuuRpcdvwSVZjnll/f7n8gBxMMh3xLTctMDKqpdfGimbMyioqtLhUYZxdJ9wGNhV7MKHvgZsQ==",
       "cpu": [
         "arm64"
       ],
@@ -1334,9 +1357,9 @@
       }
     },
     "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.2.4.tgz",
-      "integrity": "sha512-ESlKG0EpVJQwRjXDDa9rLvhEAh0mhP1sF7sap9dNZT0yyl9SAG6T7gdP09EH0vIv0UNTlo6jPWyujD6559fZvw==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.0.tgz",
+      "integrity": "sha512-Mvrf2kXW/yeW/OTezZlCGOirXRcUuLIBx/5Y12BaPM7wJoryG6dfS/NJL8aBPqtTEx/Vm4T4vKzFUcKDT+TKUA==",
       "cpu": [
         "x64"
       ],
@@ -1350,22 +1373,22 @@
       }
     },
     "node_modules/@tailwindcss/postcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.2.4.tgz",
-      "integrity": "sha512-wgAVj6nUWAolAu8YFvzT2cTBIElWHkjZwFYovF+xsqKsW2ADxM/X2opxj5NsF/qVccAOjRNe8X2IdPzMsWyHTg==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.0.tgz",
+      "integrity": "sha512-Jm05Tjx+9yCLGv5qw1c+84Psds8MnyrEQYCB+FFk2lgGiUjlRqdxke4mVTuYrj2xnVZqKim2Apr5ySuQRYAw/w==",
       "license": "MIT",
       "dependencies": {
         "@alloc/quick-lru": "^5.2.0",
-        "@tailwindcss/node": "4.2.4",
-        "@tailwindcss/oxide": "4.2.4",
-        "postcss": "^8.5.6",
-        "tailwindcss": "4.2.4"
+        "@tailwindcss/node": "4.3.0",
+        "@tailwindcss/oxide": "4.3.0",
+        "postcss": "^8.5.10",
+        "tailwindcss": "4.3.0"
       }
     },
     "node_modules/@tybys/wasm-util": {
-      "version": "0.10.1",
-      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.1.tgz",
-      "integrity": "sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==",
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -1373,9 +1396,9 @@
       }
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
@@ -1404,13 +1427,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "24.12.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.0.tgz",
-      "integrity": "sha512-GYDxsZi3ChgmckRT9HPU0WEhKLP08ev/Yfcq2AstjrDASOYCSXeyjDsHg4v5t4jOj7cyDX3vmprafKlWIG9MXQ==",
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~7.16.0"
+        "undici-types": "~7.18.0"
       }
     },
     "node_modules/@types/parse-path": {
@@ -1420,9 +1443,9 @@
       "license": "MIT"
     },
     "node_modules/@types/react": {
-      "version": "19.2.14",
-      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
-      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "version": "19.2.17",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.17.tgz",
+      "integrity": "sha512-MXfmqaVPEVgkBT/aY0aGCkRWWtByiYQXo3xdQ8r5RzuFrPiRn8Gar2tQdXSUQ2GKV3bkXckek89V8wQBY2Q/Aw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1440,17 +1463,17 @@
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.58.0.tgz",
-      "integrity": "sha512-RLkVSiNuUP1C2ROIWfqX+YcUfLaSnxGE/8M+Y57lopVwg9VTYYfhuz15Yf1IzCKgZj6/rIbYTmJCUSqr76r0Wg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.61.0.tgz",
+      "integrity": "sha512-bFNvl9ZczlVb+wR2Akszf3gHfKVj/8WanXaGJ3UstTA7brNKg0cNdk6X1Psu5V7MZ2oQtzZKOEzIUehaoxbDGw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/regexpp": "^4.12.2",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/type-utils": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/type-utils": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "ignore": "^7.0.5",
         "natural-compare": "^1.4.0",
         "ts-api-utils": "^2.5.0"
@@ -1463,7 +1486,7 @@
         "url": "https://opencollective.com/typescript-eslint"
       },
       "peerDependencies": {
-        "@typescript-eslint/parser": "^8.58.0",
+        "@typescript-eslint/parser": "^8.61.0",
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
       }
@@ -1479,16 +1502,16 @@
       }
     },
     "node_modules/@typescript-eslint/parser": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.58.0.tgz",
-      "integrity": "sha512-rLoGZIf9afaRBYsPUMtvkDWykwXwUPL60HebR4JgTI8mxfFe2cQTu3AGitANp4b9B2QlVru6WzjgB2IzJKiCSA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.61.0.tgz",
+      "integrity": "sha512-5B7PfA2e1NQGCnDHd/0lW7W3gvp3d59Ryw54FYO8Uswxo9f6ikw3AZV+Xj/TvpImmpsiYyUqAfhC6kJID1jF6w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1504,14 +1527,14 @@
       }
     },
     "node_modules/@typescript-eslint/project-service": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.58.0.tgz",
-      "integrity": "sha512-8Q/wBPWLQP1j16NxoPNIKpDZFMaxl7yWIoqXWYeWO+Bbd2mjgvoF0dxP2jKZg5+x49rgKdf7Ck473M8PC3V9lg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.61.0.tgz",
+      "integrity": "sha512-DV42F7MLJO6Rax7SK1yg43tcnEfGUrurSpSxKuVX+a3RCTzBlH3fuxprrOJXKCJGAaw82xXocikJ0uQaqwXgGA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/tsconfig-utils": "^8.58.0",
-        "@typescript-eslint/types": "^8.58.0",
+        "@typescript-eslint/tsconfig-utils": "^8.61.0",
+        "@typescript-eslint/types": "^8.61.0",
         "debug": "^4.4.3"
       },
       "engines": {
@@ -1526,14 +1549,14 @@
       }
     },
     "node_modules/@typescript-eslint/scope-manager": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.58.0.tgz",
-      "integrity": "sha512-W1Lur1oF50FxSnNdGp3Vs6P+yBRSmZiw4IIjEeYxd8UQJwhUF0gDgDD/W/Tgmh73mxgEU3qX0Bzdl/NGuSPEpQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.61.0.tgz",
+      "integrity": "sha512-IWdXFHFSb6mlC3HPc7QsLDm5zYEbUla6trDEHf32D3/dnuUyXd87plScSNXSbm0/RxMvObpI17sv/EDTGrGZkA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0"
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1544,9 +1567,9 @@
       }
     },
     "node_modules/@typescript-eslint/tsconfig-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.58.0.tgz",
-      "integrity": "sha512-doNSZEVJsWEu4htiVC+PR6NpM+pa+a4ClH9INRWOWCUzMst/VA9c4gXq92F8GUD1rwhNvRLkgjfYtFXegXQF7A==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.61.0.tgz",
+      "integrity": "sha512-O5Amvdv9ztMpxpf+vmFULGG78IE6Qwdr3bCGvqwG4nwc9H2qXkOYJJnRbRHyMkQTjv1d03olqwwwzHLMqpFePQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1561,15 +1584,15 @@
       }
     },
     "node_modules/@typescript-eslint/type-utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.58.0.tgz",
-      "integrity": "sha512-aGsCQImkDIqMyx1u4PrVlbi/krmDsQUs4zAcCV6M7yPcPev+RqVlndsJy9kJ8TLihW9TZ0kbDAzctpLn5o+lOg==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.61.0.tgz",
+      "integrity": "sha512-TuBiQYIkd97yBfInHCTKVYMbX4kvEmpOEuixIuzCU9p8BGT1SfyyO0d0IfDMbPIHcjn/hWnusUX5e8v5Xg+X8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0",
         "debug": "^4.4.3",
         "ts-api-utils": "^2.5.0"
       },
@@ -1586,9 +1609,9 @@
       }
     },
     "node_modules/@typescript-eslint/types": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.58.0.tgz",
-      "integrity": "sha512-O9CjxypDT89fbHxRfETNoAnHj/i6IpRK0CvbVN3qibxlLdo5p5hcLmUuCCrHMpxiWSwKyI8mCP7qRNYuOJ0Uww==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.61.0.tgz",
+      "integrity": "sha512-9QTQpZ5Iin4CdIodfbDQFSeiSJKidgYJYug1P9CC2xWgUTvlmixViqDZNciMjwLBZyJnG4tGmPl97rVAFb1AJg==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1600,16 +1623,16 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.58.0.tgz",
-      "integrity": "sha512-7vv5UWbHqew/dvs+D3e1RvLv1v2eeZ9txRHPnEEBUgSNLx5ghdzjHa0sgLWYVKssH+lYmV0JaWdoubo0ncGYLA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.61.0.tgz",
+      "integrity": "sha512-42zatd5qSvvcV1JdDBCLxYRznvP4eIHpPoZXdkPFnAmanA4FuZ5dibSnCBggY8hQnqajPpoGjXFdZ7fIJKQnlA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/project-service": "8.58.0",
-        "@typescript-eslint/tsconfig-utils": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/visitor-keys": "8.58.0",
+        "@typescript-eslint/project-service": "8.61.0",
+        "@typescript-eslint/tsconfig-utils": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/visitor-keys": "8.61.0",
         "debug": "^4.4.3",
         "minimatch": "^10.2.2",
         "semver": "^7.7.3",
@@ -1638,9 +1661,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/brace-expansion": {
-      "version": "5.0.5",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.5.tgz",
-      "integrity": "sha512-VZznLgtwhn+Mact9tfiwx64fA9erHH/MCXEUfB/0bX/6Fz6ny5EGTXYltMocqg4xFAQZtnO3DHWWXi8RiuN7cQ==",
+      "version": "5.0.6",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.6.tgz",
+      "integrity": "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1667,9 +1690,9 @@
       }
     },
     "node_modules/@typescript-eslint/typescript-estree/node_modules/semver": {
-      "version": "7.7.4",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
-      "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
+      "version": "7.8.4",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.4.tgz",
+      "integrity": "sha512-rUCObTnP32Q08R2uuIrt7r9PlEonuTmtuXYcW6s5kjdlj3xbnwe+21yXptAUYcMAABLkYYTtnmzb3w3EDZfueA==",
       "dev": true,
       "license": "ISC",
       "bin": {
@@ -1680,16 +1703,16 @@
       }
     },
     "node_modules/@typescript-eslint/utils": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.58.0.tgz",
-      "integrity": "sha512-RfeSqcFeHMHlAWzt4TBjWOAtoW9lnsAGiP3GbaX9uVgTYYrMbVnGONEfUCiSss+xMHFl+eHZiipmA8WkQ7FuNA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.61.0.tgz",
+      "integrity": "sha512-3bzFt7ImFMW/jVYwJamDoe/dMOdFLSC6pom6rRjdh4SZJEYupyMzem8e7vKZLclLfpHjlwSAXOUxtKxGXUiLqA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.9.1",
-        "@typescript-eslint/scope-manager": "8.58.0",
-        "@typescript-eslint/types": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0"
+        "@typescript-eslint/scope-manager": "8.61.0",
+        "@typescript-eslint/types": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1704,13 +1727,13 @@
       }
     },
     "node_modules/@typescript-eslint/visitor-keys": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.58.0.tgz",
-      "integrity": "sha512-XJ9UD9+bbDo4a4epraTwG3TsNPeiB9aShrUneAVXy8q4LuwowN+qu89/6ByLMINqvIMeI9H9hOHQtg/ijrYXzQ==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.61.0.tgz",
+      "integrity": "sha512-QVLZu3ZPQEE+HICQyAMZ2yLQhxf0meY/wx6Hx14YcTNj13JB3qHlX3lJ02L3fLGHgERRH71kvYDwiXIguT3AjQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/types": "8.58.0",
+        "@typescript-eslint/types": "8.61.0",
         "eslint-visitor-keys": "^5.0.0"
       },
       "engines": {
@@ -1735,13 +1758,13 @@
       }
     },
     "node_modules/@vitejs/plugin-react": {
-      "version": "6.0.1",
-      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.1.tgz",
-      "integrity": "sha512-l9X/E3cDb+xY3SWzlG1MOGt2usfEHGMNIaegaUGFsLkb3RCn/k8/TOXBcab+OndDI4TBtktT8/9BwwW8Vi9KUQ==",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/@vitejs/plugin-react/-/plugin-react-6.0.2.tgz",
+      "integrity": "sha512-DlSMqo4WhThw4vB8Mpn0Woe9J+Jfq1geJ61AKW0QEgLzGMNwtIMdxbDUzLxcun8W7NbJO0e2Jg/Nxm3cCSVzzg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@rolldown/pluginutils": "1.0.0-rc.7"
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "engines": {
         "node": "^20.19.0 || >=22.12.0"
@@ -1821,10 +1844,22 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-6.0.2.tgz",
+      "integrity": "sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
+    },
     "node_modules/ajv": {
-      "version": "6.14.0",
-      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.14.0.tgz",
-      "integrity": "sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==",
+      "version": "6.15.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.15.0.tgz",
+      "integrity": "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1907,9 +1942,9 @@
       "license": "MIT"
     },
     "node_modules/autoprefixer": {
-      "version": "10.4.27",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.4.27.tgz",
-      "integrity": "sha512-NP9APE+tO+LuJGn7/9+cohklunJsXWiaWEfV3si4Gi/XHDwVNgkwr1J3RQYFIvPy76GmJ9/bW8vyoU1LcxwKHA==",
+      "version": "10.5.0",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.0.tgz",
+      "integrity": "sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==",
       "dev": true,
       "funding": [
         {
@@ -1927,8 +1962,8 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "browserslist": "^4.28.1",
-        "caniuse-lite": "^1.0.30001774",
+        "browserslist": "^4.28.2",
+        "caniuse-lite": "^1.0.30001787",
         "fraction.js": "^5.3.4",
         "picocolors": "^1.1.1",
         "postcss-value-parser": "^4.2.0"
@@ -1944,13 +1979,14 @@
       }
     },
     "node_modules/axios": {
-      "version": "1.15.2",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.15.2.tgz",
-      "integrity": "sha512-wLrXxPtcrPTsNlJmKjkPnNPK2Ihe0hn0wGSaTEiHRPxwjvJwT3hKmXF4dpqxmPO9SoNb2FsYXj/xEo0gHN+D5A==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.17.0.tgz",
+      "integrity": "sha512-J8SwNxprqqpbfenehxWYXE7CW+wM1BB4w3+N+g+/Wx40xM4rsLrfPmHHxSWIxJLYDgSY/HqlFPIYb2/S3rxafw==",
       "license": "MIT",
       "dependencies": {
-        "follow-redirects": "^1.15.11",
+        "follow-redirects": "^1.16.0",
         "form-data": "^4.0.5",
+        "https-proxy-agent": "^5.0.1",
         "proxy-from-env": "^2.1.0"
       }
     },
@@ -1962,9 +1998,9 @@
       "license": "MIT"
     },
     "node_modules/baseline-browser-mapping": {
-      "version": "2.10.13",
-      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.13.tgz",
-      "integrity": "sha512-BL2sTuHOdy0YT1lYieUxTw/QMtPBC3pmlJC6xk8BBYVv6vcw3SGdKemQ+Xsx9ik2F/lYDO9tqsFQH1r9PFuHKw==",
+      "version": "2.10.35",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.35.tgz",
+      "integrity": "sha512-honAfLBde0HAFLdNyBEfuuENkF6zR+ozxqxa/2zJKHBe1qzLqyTSeRKpdPEHAP03rlDGyQOPnCSxnVpVqQo9Mg==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -2017,9 +2053,9 @@
       "license": "BSD-2-Clause"
     },
     "node_modules/brace-expansion": {
-      "version": "1.1.13",
-      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.13.tgz",
-      "integrity": "sha512-9ZLprWS6EENmhEOpjCYW2c8VkmOvckIJZfkr7rBW6dObmfgJ/L1GpSYW5Hpo9lDz4D1+n0Ckz8rU7FwHDQiG/w==",
+      "version": "1.1.15",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.15.tgz",
+      "integrity": "sha512-EwOCDEex4quD37XhqM3omwtMoJjr//isUZz1JopUNWms+4Z2ViyM/k1YIRePpoVNnQhENnxtFjLaxNHrT7xIUg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2122,9 +2158,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001782",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001782.tgz",
-      "integrity": "sha512-dZcaJLJeDMh4rELYFw1tvSn1bhZWYFOt468FcbHHxx/Z/dFidd1I6ciyFdi3iwfQCyOjqo9upF6lGQYtMiJWxw==",
+      "version": "1.0.30001799",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001799.tgz",
+      "integrity": "sha512-hG1bReV+OUU+MOqK4t/ZWI0tZOyz3rqS9XuhOUz1cIcbwBKjOyJEJuw9ER5JuNyqxNk8u/JUVbGibBOL1yrjFw==",
       "dev": true,
       "funding": [
         {
@@ -2376,9 +2412,9 @@
       "license": "MIT"
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.5.329",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.329.tgz",
-      "integrity": "sha512-/4t+AS1l4S3ZC0Ja7PHFIWeBIxGA3QGqV8/yKsP36v7NcyUCl+bIcmw6s5zVuMIECWwBrAK/6QLzTmbJChBboQ==",
+      "version": "1.5.371",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.371.tgz",
+      "integrity": "sha512-e9htk9mAYL6AzmkEhSvVVw7IWGSBJ/Bqdn2eRyRLrj1g6sncN4WbFt5qnILYoCktktr45pyjIrOiRvBThQ808w==",
       "dev": true,
       "license": "ISC"
     },
@@ -2391,14 +2427,36 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/engine.io-client": {
+      "version": "6.6.5",
+      "resolved": "https://registry.npmjs.org/engine.io-client/-/engine.io-client-6.6.5.tgz",
+      "integrity": "sha512-QCwxUDULPlXv8F6tqMMKx5dNkTe6OaBYRMPYeXKBlyOoKvAmE0ac6pW7fFhSscJ/5SI7666/U/B+MElbsrJlIg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.20.1",
+        "xmlhttprequest-ssl": "~2.1.1"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/enhanced-resolve": {
-      "version": "5.20.1",
-      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.20.1.tgz",
-      "integrity": "sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==",
+      "version": "5.24.0",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.24.0.tgz",
+      "integrity": "sha512-SkE2t82KlkkxQRVMVLAGKxLfORGQfrkx5dkj+vlgXRVNEdPc4eZcR+J/Fvj8C+yKSFH5L0q3NFlyufOVQnCcYQ==",
       "license": "MIT",
       "dependencies": {
         "graceful-fs": "^4.2.4",
-        "tapable": "^2.3.0"
+        "tapable": "^2.3.3"
       },
       "engines": {
         "node": ">=10.13.0"
@@ -2423,9 +2481,9 @@
       }
     },
     "node_modules/es-object-atoms": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
-      "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.2.tgz",
+      "integrity": "sha512-HWcBoN6NileqtSydK2FqHbS/LoDd2pqrnQHLyJzBj4kOp/ky2MWMN694xOfkK8/SnUsW2DH7EfyVlydKCsm1Zw==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -2539,9 +2597,9 @@
       }
     },
     "node_modules/eslint-plugin-react-hooks": {
-      "version": "7.0.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.0.1.tgz",
-      "integrity": "sha512-O0d0m04evaNzEPoSW+59Mezf8Qt0InfgGIBJnpC0h3NH/WjUAR7BIKUfysC6todmtiZ/A0oUVS8Gce0WhBrHsA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-7.1.1.tgz",
+      "integrity": "sha512-f2I7Gw6JbvCexzIInuSbZpfdQ44D7iqdWX01FKLvrPgqxoE7oMj8clOfto8U6vYiz4yd5oKu39rRSVOe1zRu0g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2555,7 +2613,7 @@
         "node": ">=18"
       },
       "peerDependencies": {
-        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0"
+        "eslint": "^3.0.0 || ^4.0.0 || ^5.0.0 || ^6.0.0 || ^7.0.0 || ^8.0.0-0 || ^9.0.0 || ^10.0.0"
       }
     },
     "node_modules/eslint-plugin-react-refresh": {
@@ -2979,9 +3037,9 @@
       "license": "ISC"
     },
     "node_modules/follow-redirects": {
-      "version": "1.15.11",
-      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.15.11.tgz",
-      "integrity": "sha512-deG2P0JfjrTxl50XGCDyfI97ZGVCxIpfKYmfyrQ54n5FO/0gfIES8C/Psl6kWVDolizcaaxZJnTS0QSMxvnsBQ==",
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
       "funding": [
         {
           "type": "individual",
@@ -3038,13 +3096,13 @@
       }
     },
     "node_modules/framer-motion": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.38.0.tgz",
-      "integrity": "sha512-rFYkY/pigbcswl1XQSb7q424kSTQ8q6eAC+YUsSKooHQYuLdzdHjrt6uxUC+PRAO++q5IS7+TamgIw1AphxR+g==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.40.0.tgz",
+      "integrity": "sha512-uaBd3qC1v3KQqBEjwTUd183K6PbS+j0yR9w9VmEOLWA/tnUcSn8Xa3uck7t4dgpDoUss8xQTcj8W2L07lrnLFg==",
       "license": "MIT",
       "dependencies": {
-        "motion-dom": "^12.38.0",
-        "motion-utils": "^12.36.0",
+        "motion-dom": "^12.40.0",
+        "motion-utils": "^12.39.0",
         "tslib": "^2.4.0"
       },
       "peerDependencies": {
@@ -3177,9 +3235,9 @@
       }
     },
     "node_modules/globals": {
-      "version": "17.4.0",
-      "resolved": "https://registry.npmjs.org/globals/-/globals-17.4.0.tgz",
-      "integrity": "sha512-hjrNztw/VajQwOLsMNT1cbJiH2muO3OROCHnbehc8eY5JyD2gqz4AcMHPqgaOR59DjgUjYAYLeH699g/eWi2jw==",
+      "version": "17.6.0",
+      "resolved": "https://registry.npmjs.org/globals/-/globals-17.6.0.tgz",
+      "integrity": "sha512-sepffkT8stwnIYbsMBpoCHJuJM5l98FUF2AnE07hfvE0m/qp3R586hw4jF4uadbhvg1ooIdzuu7CsfD2jzCaNA==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -3219,9 +3277,9 @@
       }
     },
     "node_modules/goober": {
-      "version": "2.1.18",
-      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.18.tgz",
-      "integrity": "sha512-2vFqsaDVIT9Gz7N6kAL++pLpp41l3PfDuusHcjnGLfR6+huZkl6ziX+zgVC3ZxpqWhzH6pyDdGrCeDhMIvwaxw==",
+      "version": "2.1.19",
+      "resolved": "https://registry.npmjs.org/goober/-/goober-2.1.19.tgz",
+      "integrity": "sha512-U7veizMqxyKlM58+Z5j2ngJBH/r9siDmxpvNxSw0PylF6WQvrASJEZrxh1hidRBJc2jqoBVSyOban5u8m+6Rxg==",
       "license": "MIT",
       "peerDependencies": {
         "csstype": "^3.0.10"
@@ -3310,9 +3368,9 @@
       }
     },
     "node_modules/hasown": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-      "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+      "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -3339,9 +3397,9 @@
       }
     },
     "node_modules/hono": {
-      "version": "4.12.23",
-      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.23.tgz",
-      "integrity": "sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==",
+      "version": "4.12.25",
+      "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.25.tgz",
+      "integrity": "sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==",
       "license": "MIT",
       "engines": {
         "node": ">=16.9.0"
@@ -3365,6 +3423,19 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-5.0.1.tgz",
+      "integrity": "sha512-dFcAjpTQFgoLMzC2VwU+C/CbS7uRL0lWmxDITmqm7C+7F0Odmj6s9l6alZc6AELXhrnggM2CeWSXHGOdX2YtwA==",
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "6",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/iconv-lite": {
@@ -3559,10 +3630,20 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.1.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
-      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.2.0.tgz",
+      "integrity": "sha512-ePWsvanv0DWuDRsW8dnt+R4jQ31SCRCQ7hhNcPXZPsoBZiemuZNYGf7adZdqX2D86j6rvKp3RpCxVTSb8WQlOw==",
       "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
       "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
@@ -3957,9 +4038,9 @@
       }
     },
     "node_modules/lucide-react": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.7.0.tgz",
-      "integrity": "sha512-yI7BeItCLZJTXikmK4KNUGCKoGzSvbKlfCvw44bU4fXAL6v3gYS4uHD1jzsLkfwODYwI6Drw5Tu9Z5ulDe0TSg==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-1.17.0.tgz",
+      "integrity": "sha512-9FA9evdox/JQL5PT57fdA1x/yg8T7knJ98+zjTL3UfKza6pflQUUh3XtaQIHKvnsJw1lmsEyHVlt5jchYxOQ5w==",
       "license": "ISC",
       "peerDependencies": {
         "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
@@ -4024,18 +4105,6 @@
       },
       "engines": {
         "node": ">=8.6"
-      }
-    },
-    "node_modules/micromatch/node_modules/picomatch": {
-      "version": "2.3.2",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
-      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=8.6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/mime-db": {
@@ -4103,18 +4172,18 @@
       }
     },
     "node_modules/motion-dom": {
-      "version": "12.38.0",
-      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.38.0.tgz",
-      "integrity": "sha512-pdkHLD8QYRp8VfiNLb8xIBJis1byQ9gPT3Jnh2jqfFtAsWUA3dEepDlsWe/xMpO8McV+VdpKVcp+E+TGJEtOoA==",
+      "version": "12.40.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.40.0.tgz",
+      "integrity": "sha512-HxU3ZaBwNPVQUBQf1xxgq+7JrPNZvjLVxgbpEZL7RrWJnsxOf0/OM+yrHG9ogLQ31Do/r57Oz2gQWPK+6q62mg==",
       "license": "MIT",
       "dependencies": {
-        "motion-utils": "^12.36.0"
+        "motion-utils": "^12.39.0"
       }
     },
     "node_modules/motion-utils": {
-      "version": "12.36.0",
-      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.36.0.tgz",
-      "integrity": "sha512-eHWisygbiwVvf6PZ1vhaHCLamvkSbPIeAYxWUuL3a2PD/TROgE7FvfHWTIH4vMl798QLfMw15nRqIaRDXTlYRg==",
+      "version": "12.39.0",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.39.0.tgz",
+      "integrity": "sha512-8nadJAJjTtqRkmRF36FoJTrywK9nnFmnPwnSMyxaOCU7GDjN9RTMJIxx9De8ErM+vpPhMccr/6fo5WciyQLnMQ==",
       "license": "MIT"
     },
     "node_modules/ms": {
@@ -4124,9 +4193,9 @@
       "license": "MIT"
     },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "funding": [
         {
           "type": "github",
@@ -4164,11 +4233,14 @@
       "license": "MIT"
     },
     "node_modules/node-releases": {
-      "version": "2.0.36",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.36.tgz",
-      "integrity": "sha512-TdC8FSgHz8Mwtw9g5L4gR/Sh9XhSP/0DEkQxfEFXOpiul5IiHgHan2VhYYb6agDSfp4KuvltmGApc8HMgUrIkA==",
+      "version": "2.0.47",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.47.tgz",
+      "integrity": "sha512-Uzmd6LXpouKo8EUK68IjH4+E01w/hXyV3R3g/geCJo+rXLNfh1xucB+LOzYEOQPSiUK3h/xZf0cQGcSsmyL2Og==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/object-assign": {
       "version": "4.1.1",
@@ -4357,13 +4429,12 @@
       "license": "ISC"
     },
     "node_modules/picomatch": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
-      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
-      "dev": true,
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.2.tgz",
+      "integrity": "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==",
       "license": "MIT",
       "engines": {
-        "node": ">=12"
+        "node": ">=8.6"
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
@@ -4388,9 +4459,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.15",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.15.tgz",
+      "integrity": "sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==",
       "funding": [
         {
           "type": "opencollective",
@@ -4407,7 +4478,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.11",
+        "nanoid": "^3.3.12",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -4555,9 +4626,9 @@
       }
     },
     "node_modules/react-hook-form": {
-      "version": "7.73.1",
-      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.73.1.tgz",
-      "integrity": "sha512-VAfVYOPcx3piiEVQy95vyFmBwbVUsP/AUIN+mpFG8h11yshDd444nn0VyfaGWSRnhOLVgiDu7HIuBtAIzxn9dA==",
+      "version": "7.78.0",
+      "resolved": "https://registry.npmjs.org/react-hook-form/-/react-hook-form-7.78.0.tgz",
+      "integrity": "sha512-EEZqc+N23moyzTlz61Pj+JvcXo76ICkpfOZo8JZw+sM4+wLQGh6nI2Ms+PdMOYNluFu0ghlM7B8mCzhRYtJCnA==",
       "license": "MIT",
       "engines": {
         "node": ">=18.0.0"
@@ -4602,9 +4673,9 @@
       }
     },
     "node_modules/react-router": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.14.2.tgz",
-      "integrity": "sha512-yCqNne6I8IB6rVCH7XUvlBK7/QKyqypBFGv+8dj4QBFJiiRX+FG7/nkdAvGElyvVZ/HQP5N19wzteuTARXi5Gw==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-7.17.0.tgz",
+      "integrity": "sha512-FDELK7rTMlCHO5+reyXsPlmfr7N1F91lPHsWYfMEGQm/KQ+F4JFM8jGoeQDmDvdTs93Fw9aSilH+uKRb4/jXvQ==",
       "license": "MIT",
       "dependencies": {
         "cookie": "^1.0.1",
@@ -4624,12 +4695,12 @@
       }
     },
     "node_modules/react-router-dom": {
-      "version": "7.14.2",
-      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.14.2.tgz",
-      "integrity": "sha512-YZcM5ES8jJSM+KrJ9BdvHHqlnGTg5tH3sC5ChFRj4inosKctdyzBDhOyyHdGk597q2OT6NTrCA1OvB/YDwfekQ==",
+      "version": "7.17.0",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-7.17.0.tgz",
+      "integrity": "sha512-fyU2yjGups/hE6Xz0I5ZYbVL8Gx29eCjgpHaRaTaVU+OOAdfRX05KsvyRm0GO8YQwOkhpU3MurW1jyMUJn+zSw==",
       "license": "MIT",
       "dependencies": {
-        "react-router": "7.14.2"
+        "react-router": "7.17.0"
       },
       "engines": {
         "node": ">=20.0.0"
@@ -4747,14 +4818,14 @@
       }
     },
     "node_modules/rolldown": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0-rc.12.tgz",
-      "integrity": "sha512-yP4USLIMYrwpPHEFB5JGH1uxhcslv6/hL0OyvTuY+3qlOSJvZ7ntYnoWpehBxufkgN0cvXxppuTu5hHa/zPh+A==",
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.3.tgz",
+      "integrity": "sha512-i00lAJ2ks1BYr7rjNjKC7BcqAS7nVfiT3QX1SI5aY+AFHblCmaUf9OE9dbdzDvW6dJxbi2ZCZiy9v3CcwOiX3g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@oxc-project/types": "=0.122.0",
-        "@rolldown/pluginutils": "1.0.0-rc.12"
+        "@oxc-project/types": "=0.133.0",
+        "@rolldown/pluginutils": "^1.0.0"
       },
       "bin": {
         "rolldown": "bin/cli.mjs"
@@ -4763,29 +4834,22 @@
         "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rolldown/binding-android-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-darwin-x64": "1.0.0-rc.12",
-        "@rolldown/binding-freebsd-x64": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-arm64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-linux-ppc64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-s390x-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-gnu": "1.0.0-rc.12",
-        "@rolldown/binding-linux-x64-musl": "1.0.0-rc.12",
-        "@rolldown/binding-openharmony-arm64": "1.0.0-rc.12",
-        "@rolldown/binding-wasm32-wasi": "1.0.0-rc.12",
-        "@rolldown/binding-win32-arm64-msvc": "1.0.0-rc.12",
-        "@rolldown/binding-win32-x64-msvc": "1.0.0-rc.12"
+        "@rolldown/binding-android-arm64": "1.0.3",
+        "@rolldown/binding-darwin-arm64": "1.0.3",
+        "@rolldown/binding-darwin-x64": "1.0.3",
+        "@rolldown/binding-freebsd-x64": "1.0.3",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.3",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.3",
+        "@rolldown/binding-linux-arm64-musl": "1.0.3",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.3",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-gnu": "1.0.3",
+        "@rolldown/binding-linux-x64-musl": "1.0.3",
+        "@rolldown/binding-openharmony-arm64": "1.0.3",
+        "@rolldown/binding-wasm32-wasi": "1.0.3",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.3",
+        "@rolldown/binding-win32-x64-msvc": "1.0.3"
       }
-    },
-    "node_modules/rolldown/node_modules/@rolldown/pluginutils": {
-      "version": "1.0.0-rc.12",
-      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0-rc.12.tgz",
-      "integrity": "sha512-HHMwmarRKvoFsJorqYlFeFRzXZqCt2ETQlEDOb9aqssrnVBB1/+xgTGtuTrIk5vzLNX1MjMtTf7W9z3tsSbrxw==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/router": {
       "version": "2.2.0",
@@ -4955,14 +5019,14 @@
       }
     },
     "node_modules/side-channel": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.0.tgz",
-      "integrity": "sha512-ZX99e6tRweoUXqR+VBrslhda51Nh5MTQwou5tnUDgbtyM0dBgmhEDtWGP/xbKn6hqfPRHujUNwz5fy/wbbhnpw==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.1.1.tgz",
+      "integrity": "sha512-6x6dK6zJdpTzF4sQeNYxwtvBzf6Eg4GtlesS94HOvTudUeyK2WXAaIfmDgsyslYrRBeFIlsi54AYsFGUuhmvrQ==",
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
-        "object-inspect": "^1.13.3",
-        "side-channel-list": "^1.0.0",
+        "object-inspect": "^1.13.4",
+        "side-channel-list": "^1.0.1",
         "side-channel-map": "^1.0.1",
         "side-channel-weakmap": "^1.0.2"
       },
@@ -5044,6 +5108,34 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/socket.io-client": {
+      "version": "4.8.3",
+      "resolved": "https://registry.npmjs.org/socket.io-client/-/socket.io-client-4.8.3.tgz",
+      "integrity": "sha512-uP0bpjWrjQmUt5DTHq9RuoCBdFJF10cdX9X+a368j/Ft0wmaVgxlrjvK3kjvgCODOMMOz9lcaRzxmso0bTWZ/g==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1",
+        "engine.io-client": "~6.6.1",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.6",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.6.tgz",
+      "integrity": "sha512-asJqbVBDsBCJx0pTqw3WfesSY0iRX+2xzWEWzrpcH7L6fLzrhyF8WPI8UaeM4YCuDfpwA/cgsdugMsmtz8EJeg==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.4.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
     "node_modules/source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -5107,9 +5199,9 @@
       }
     },
     "node_modules/tailwindcss": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.2.4.tgz",
-      "integrity": "sha512-HhKppgO81FQof5m6TEnuBWCZGgfRAWbaeOaGT00KOy/Pf/j6oUihdvBpA7ltCeAvZpFhW3j0PTclkxsd4IXYDA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
+      "integrity": "sha512-y6nxMGB1nMW9R6k96e5gdIFzcfL/gTJRNaqGes1YvkLnPVXzWgbqFF2yLC0T8G774n24cx3Pe8XrKoniCOAH+Q==",
       "license": "MIT"
     },
     "node_modules/tapable": {
@@ -5126,9 +5218,9 @@
       }
     },
     "node_modules/tar": {
-      "version": "7.5.15",
-      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.15.tgz",
-      "integrity": "sha512-dzGK0boVlC4W5QFuQN1EFSl3bIDYsk7Tj40U6eIBnK2k/8ml7TZ5agbI5j5+qnoVcAA+rNtBml8SEiLxZpNqRQ==",
+      "version": "7.5.16",
+      "resolved": "https://registry.npmjs.org/tar/-/tar-7.5.16.tgz",
+      "integrity": "sha512-56adEpPMouktRlBLXiaYFFzZ/3+JXa8P9n7WbR+ibIjtviN55mEaOkiysCnPnWm+7kkui1Dn8J9l+g6zV8731w==",
       "license": "BlueOak-1.0.0",
       "dependencies": {
         "@isaacs/fs-minipass": "^4.0.0",
@@ -5151,29 +5243,42 @@
       }
     },
     "node_modules/tinyclip": {
-      "version": "0.1.13",
-      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.13.tgz",
-      "integrity": "sha512-8OqlXQ35euK9+e7L68u8UwcODxkHoIkjbGsgXuARKNyQ5G6xt8nw1YPeMbxMLgCPFkToU+UEK5j05t2t8edKpQ==",
+      "version": "0.1.14",
+      "resolved": "https://registry.npmjs.org/tinyclip/-/tinyclip-0.1.14.tgz",
+      "integrity": "sha512-F1oWdz8tjT17qe1d5JgDK6z03WGOhYYAN0lK3/D/fzNiy93xswLLEw7pk+3g05onhAy6Bsc6PLNUGhdgVjemMQ==",
       "license": "MIT",
       "engines": {
         "node": "^16.14.0 || >= 17.3.0"
       }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.17",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.17.tgz",
+      "integrity": "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinyglobby/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
     "node_modules/tinypool": {
@@ -5298,7 +5403,7 @@
       "version": "5.9.3",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
-      "devOptional": true,
+      "dev": true,
       "license": "Apache-2.0",
       "bin": {
         "tsc": "bin/tsc",
@@ -5309,16 +5414,16 @@
       }
     },
     "node_modules/typescript-eslint": {
-      "version": "8.58.0",
-      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.58.0.tgz",
-      "integrity": "sha512-e2TQzKfaI85fO+F3QywtX+tCTsu/D3WW5LVU6nz8hTFKFZ8yBJ6mSYRpXqdR3mFjPWmO0eWsTa5f+UpAOe/FMA==",
+      "version": "8.61.0",
+      "resolved": "https://registry.npmjs.org/typescript-eslint/-/typescript-eslint-8.61.0.tgz",
+      "integrity": "sha512-8y31Rd0eGTrDKqhy6vT0HtzhN+YLjQizwX3aA3hPXP/ynSfnrBXcQY5IzsP9/DM7+klX4IUncZZjkchP0z+rUw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@typescript-eslint/eslint-plugin": "8.58.0",
-        "@typescript-eslint/parser": "8.58.0",
-        "@typescript-eslint/typescript-estree": "8.58.0",
-        "@typescript-eslint/utils": "8.58.0"
+        "@typescript-eslint/eslint-plugin": "8.61.0",
+        "@typescript-eslint/parser": "8.61.0",
+        "@typescript-eslint/typescript-estree": "8.61.0",
+        "@typescript-eslint/utils": "8.61.0"
       },
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5346,9 +5451,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "7.16.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
-      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
       "dev": true,
       "license": "MIT"
     },
@@ -5438,17 +5543,17 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.3.tgz",
-      "integrity": "sha512-B9ifbFudT1TFhfltfaIPgjo9Z3mDynBTJSUYxTjOQruf/zHH+ezCQKcoqO+h7a9Pw9Nm/OtlXAiGT1axBgwqrQ==",
+      "version": "8.0.16",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.16.tgz",
+      "integrity": "sha512-h9bXPmJichP5fLmVQo3PyaGSDE2n3aPuomeAlVRm0JLmt4rY6zmPKd59HYI4LNW8oTK7tlTsuC7l/m7awx9Jcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.4",
-        "postcss": "^8.5.8",
-        "rolldown": "1.0.0-rc.12",
-        "tinyglobby": "^0.2.15"
+        "postcss": "^8.5.15",
+        "rolldown": "1.0.3",
+        "tinyglobby": "^0.2.17"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -5464,8 +5569,8 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
-        "@vitejs/devtools": "^0.1.0",
-        "esbuild": "^0.27.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
         "sass": "^1.70.0",
@@ -5515,6 +5620,19 @@
         }
       }
     },
+    "node_modules/vite/node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
     "node_modules/web-tree-sitter": {
       "version": "0.26.9",
       "resolved": "https://registry.npmjs.org/web-tree-sitter/-/web-tree-sitter-0.26.9.tgz",
@@ -5558,6 +5676,27 @@
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
       "license": "ISC"
     },
+    "node_modules/ws": {
+      "version": "8.20.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
+      "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/xml-naming": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/xml-naming/-/xml-naming-0.1.0.tgz",
@@ -5571,6 +5710,14 @@
       "license": "MIT",
       "engines": {
         "node": ">=16.0.0"
+      }
+    },
+    "node_modules/xmlhttprequest-ssl": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/xmlhttprequest-ssl/-/xmlhttprequest-ssl-2.1.2.tgz",
+      "integrity": "sha512-TEU+nJVUUnA4CYJFLvK5X9AOeH4KvDvhIfm0vV1GaQRtchnG0hgK5p8hw/xjv8cunWYCsiPCSDzObPyhEwq3KQ==",
+      "engines": {
+        "node": ">=0.4.0"
       }
     },
     "node_modules/yallist": {

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -23,6 +23,7 @@
     "react-leaflet": "^4.2.1",
     "react-router-dom": "^7.14.2",
     "repomix": "^1.14.1",
+    "socket.io-client": "^4.8.3",
     "zod": "^4.3.6"
   },
   "devDependencies": {

--- a/Frontend/src/application/use-cases/GetCourierOrdersUseCase.ts
+++ b/Frontend/src/application/use-cases/GetCourierOrdersUseCase.ts
@@ -1,0 +1,10 @@
+import type { ICourierOrdersRepository } from "../../domain/interfaces/ICourierOrdersRepository";
+import type { CourierOrder } from "../../domain/types/courier-orders.types";
+
+export class GetCourierOrdersUseCase {
+  constructor(private readonly repo: ICourierOrdersRepository) {}
+
+  async execute(courierId: number): Promise<CourierOrder[]> {
+    return this.repo.getByCourier(courierId);
+  }
+}

--- a/Frontend/src/application/use-cases/GetLastLocationUseCase.ts
+++ b/Frontend/src/application/use-cases/GetLastLocationUseCase.ts
@@ -1,0 +1,14 @@
+import type { ITrackingRepository } from "../../domain/interfaces/ITrackingRepository";
+import type { OrderTracking } from "../../domain/types/tracking.types";
+
+/**
+ * Fallback REST: obtiene la última ubicación conocida del pedido.
+ * Se usa al cargar la pantalla y como respaldo si el WebSocket falla.
+ */
+export class GetLastLocationUseCase {
+  constructor(private readonly trackingRepository: ITrackingRepository) {}
+
+  async execute(orderId: string): Promise<OrderTracking> {
+    return this.trackingRepository.getOrderTracking(orderId);
+  }
+}

--- a/Frontend/src/application/use-cases/SendCourierLocationUseCase.ts
+++ b/Frontend/src/application/use-cases/SendCourierLocationUseCase.ts
@@ -1,0 +1,13 @@
+import type { ITrackingGateway } from "../../domain/interfaces/ITrackingGateway";
+import type { LocationUpdateInput } from "../../domain/types/tracking.types";
+
+/**
+ * Domiciliario: emite su ubicación actual al backend vía WebSocket.
+ */
+export class SendCourierLocationUseCase {
+  constructor(private readonly gateway: ITrackingGateway) {}
+
+  execute(input: LocationUpdateInput): void {
+    this.gateway.sendLocation(input);
+  }
+}

--- a/Frontend/src/application/use-cases/SubscribeToOrderTrackingUseCase.ts
+++ b/Frontend/src/application/use-cases/SubscribeToOrderTrackingUseCase.ts
@@ -1,0 +1,15 @@
+import type { ITrackingGateway } from "../../domain/interfaces/ITrackingGateway";
+
+/**
+ * Visor (usuario/negocio/admin): se conecta y suscribe al tracking de un pedido.
+ */
+export class SubscribeToOrderTrackingUseCase {
+  constructor(private readonly gateway: ITrackingGateway) {}
+
+  execute(token: string, orderId: string): void {
+    if (!this.gateway.isConnected()) {
+      this.gateway.connect(token);
+    }
+    this.gateway.subscribeToOrder(orderId);
+  }
+}

--- a/Frontend/src/domain/interfaces/ICourierOrdersRepository.ts
+++ b/Frontend/src/domain/interfaces/ICourierOrdersRepository.ts
@@ -1,0 +1,5 @@
+import type { CourierOrder } from "../types/courier-orders.types";
+
+export interface ICourierOrdersRepository {
+  getByCourier(courierId: number): Promise<CourierOrder[]>;
+}

--- a/Frontend/src/domain/interfaces/ITrackingGateway.ts
+++ b/Frontend/src/domain/interfaces/ITrackingGateway.ts
@@ -1,0 +1,24 @@
+import type { CourierLocation, LocationUpdateInput } from "../types/tracking.types";
+
+/**
+ * Contrato del transporte en tiempo real.
+ * Abstrae socket.io: la capa de aplicación/ui no sabe qué tecnología hay debajo.
+ * Implementado por TrackingSocketGateway sobre socket.io-client.
+ */
+export interface ITrackingGateway {
+  connect(token: string): void;
+  disconnect(): void;
+  isConnected(): boolean;
+
+  /** Visor: se suscribe al tracking de un pedido */
+  subscribeToOrder(orderId: string): void;
+
+  /** Domiciliario: emite su ubicación actual */
+  sendLocation(input: LocationUpdateInput): void;
+
+  /** Callbacks de eventos entrantes */
+  onLocation(cb: (location: CourierLocation) => void): void;
+  onTrackingClosed(cb: (data: { order_id: string; message: string }) => void): void;
+  onError(cb: (data: { message: string }) => void): void;
+  onConnectionChange(cb: (connected: boolean) => void): void;
+}

--- a/Frontend/src/domain/interfaces/ITrackingRepository.ts
+++ b/Frontend/src/domain/interfaces/ITrackingRepository.ts
@@ -1,0 +1,9 @@
+import type { OrderTracking } from "../types/tracking.types";
+
+/**
+ * Contrato del fallback REST (sin tiempo real).
+ * Implementado por TrackingRepositoryImpl sobre axios.
+ */
+export interface ITrackingRepository {
+  getOrderTracking(orderId: string): Promise<OrderTracking>;
+}

--- a/Frontend/src/domain/types/courier-orders.types.ts
+++ b/Frontend/src/domain/types/courier-orders.types.ts
@@ -1,0 +1,21 @@
+export interface CourierOrderItem {
+  product_id: string;
+  product_name: string;
+  quantity: number;
+  unit_price: number;
+}
+
+export interface CourierOrder {
+  order_id: string;
+  user_id: number;
+  vendor_id: number;
+  courier_id: number | null;
+  status: string;
+  delivery_address: string;
+  subtotal: number;
+  delivery_fee: number;
+  platform_commission: number;
+  total: number;
+  items: CourierOrderItem[];
+  created_at: string | null;
+}

--- a/Frontend/src/domain/types/recent-orders.types.ts
+++ b/Frontend/src/domain/types/recent-orders.types.ts
@@ -7,7 +7,7 @@ export interface OrderItem {
 export interface RecentOrder {
   order_id: string;
   customer_name: string;
-  status: 'PENDING' | 'ACCEPTED' | 'PREPARING' | 'READY';
+  status: 'PENDING' | 'ACCEPTED' | 'PREPARING' | 'READY' | 'IN_DELIVERY' | 'DELIVERED' | 'CANCELLED';
   courier_name: string | null;
   total: number;
   time_elapsed: string;

--- a/Frontend/src/domain/types/tracking.types.ts
+++ b/Frontend/src/domain/types/tracking.types.ts
@@ -1,0 +1,40 @@
+/**
+ * DOMAIN LAYER - Tipos puros de rastreo GPS
+ * No dependen de ninguna tecnología (ni socket.io ni axios)
+ */
+
+export interface CourierLocation {
+  courier_id: number;
+  order_id: string;
+  lat: number;
+  lng: number;
+  accuracy: number | null;
+  speed: number | null;
+  heading: number | null;
+  timestamp: string; // ISO
+}
+
+/** Coordenadas que envía el domiciliario desde el navegador */
+export interface LocationUpdateInput {
+  order_id: string;
+  lat: number;
+  lng: number;
+  accuracy?: number;
+  speed?: number;
+  heading?: number;
+}
+
+/** Respuesta del fallback REST GET /tracking/order/:orderId */
+export interface OrderTracking {
+  order_id: string;
+  courier_id: number | null;
+  status: string;
+  location: CourierLocation | null;
+}
+
+export type TrackingConnectionState =
+  | "idle"
+  | "connecting"
+  | "connected"
+  | "disconnected"
+  | "error";

--- a/Frontend/src/infrastructure/api/courierOrdersApi.ts
+++ b/Frontend/src/infrastructure/api/courierOrdersApi.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { authLocalStorage } from "../persistence/authLocalStorage";
+import type { CourierOrder } from "../../domain/types/courier-orders.types";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export const courierOrdersApi = {
+  getByCourier: async (courierId: number): Promise<CourierOrder[]> => {
+    const token = authLocalStorage.getToken();
+    const response = await axios.get(`${API_URL}/orders/courier/${courierId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+};

--- a/Frontend/src/infrastructure/api/trackingApi.ts
+++ b/Frontend/src/infrastructure/api/trackingApi.ts
@@ -1,0 +1,15 @@
+import axios from "axios";
+import { authLocalStorage } from "../persistence/authLocalStorage";
+import type { OrderTracking } from "../../domain/types/tracking.types";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+export const trackingApi = {
+  getOrderTracking: async (orderId: string): Promise<OrderTracking> => {
+    const token = authLocalStorage.getToken();
+    const response = await axios.get(`${API_URL}/tracking/order/${orderId}`, {
+      headers: { Authorization: `Bearer ${token}` },
+    });
+    return response.data;
+  },
+};

--- a/Frontend/src/infrastructure/repositories/CourierOrdersRepositoryImpl.ts
+++ b/Frontend/src/infrastructure/repositories/CourierOrdersRepositoryImpl.ts
@@ -1,0 +1,9 @@
+import type { ICourierOrdersRepository } from "../../domain/interfaces/ICourierOrdersRepository";
+import type { CourierOrder } from "../../domain/types/courier-orders.types";
+import { courierOrdersApi } from "../api/courierOrdersApi";
+
+export class CourierOrdersRepositoryImpl implements ICourierOrdersRepository {
+  async getByCourier(courierId: number): Promise<CourierOrder[]> {
+    return courierOrdersApi.getByCourier(courierId);
+  }
+}

--- a/Frontend/src/infrastructure/repositories/TrackingRepositoryImpl.ts
+++ b/Frontend/src/infrastructure/repositories/TrackingRepositoryImpl.ts
@@ -1,0 +1,9 @@
+import type { ITrackingRepository } from "../../domain/interfaces/ITrackingRepository";
+import type { OrderTracking } from "../../domain/types/tracking.types";
+import { trackingApi } from "../api/trackingApi";
+
+export class TrackingRepositoryImpl implements ITrackingRepository {
+  async getOrderTracking(orderId: string): Promise<OrderTracking> {
+    return trackingApi.getOrderTracking(orderId);
+  }
+}

--- a/Frontend/src/infrastructure/socket/TrackingSocketGateway.ts
+++ b/Frontend/src/infrastructure/socket/TrackingSocketGateway.ts
@@ -1,0 +1,59 @@
+import { io, type Socket } from "socket.io-client";
+import type { ITrackingGateway } from "../../domain/interfaces/ITrackingGateway";
+import type { CourierLocation, LocationUpdateInput } from "../../domain/types/tracking.types";
+
+const API_URL = import.meta.env.VITE_API_URL || "http://localhost:3000";
+
+/**
+ * INFRASTRUCTURE - Adaptador de socket.io-client al contrato ITrackingGateway.
+ * Se conecta al namespace /tracking del backend.
+ */
+export class TrackingSocketGateway implements ITrackingGateway {
+  private socket: Socket | null = null;
+
+  connect(token: string): void {
+    if (this.socket?.connected) return;
+
+    this.socket = io(`${API_URL}/tracking`, {
+      auth: { token },
+      transports: ["websocket"],
+      reconnection: true,
+      reconnectionAttempts: 5,
+      reconnectionDelay: 2000,
+    });
+  }
+
+  disconnect(): void {
+    this.socket?.disconnect();
+    this.socket = null;
+  }
+
+  isConnected(): boolean {
+    return this.socket?.connected ?? false;
+  }
+
+  subscribeToOrder(orderId: string): void {
+    this.socket?.emit("order:tracking", { order_id: orderId });
+  }
+
+  sendLocation(input: LocationUpdateInput): void {
+    this.socket?.emit("courier:location:update", input);
+  }
+
+  onLocation(cb: (location: CourierLocation) => void): void {
+    this.socket?.on("courier:location", cb);
+  }
+
+  onTrackingClosed(cb: (data: { order_id: string; message: string }) => void): void {
+    this.socket?.on("tracking:closed", cb);
+  }
+
+  onError(cb: (data: { message: string }) => void): void {
+    this.socket?.on("error", cb);
+  }
+
+  onConnectionChange(cb: (connected: boolean) => void): void {
+    this.socket?.on("connect", () => cb(true));
+    this.socket?.on("disconnect", () => cb(false));
+  }
+}

--- a/Frontend/src/ui/components/DeliveryMap/LiveTrackingMap.tsx
+++ b/Frontend/src/ui/components/DeliveryMap/LiveTrackingMap.tsx
@@ -1,0 +1,76 @@
+import { useEffect, useState } from "react";
+import { MapContainer, TileLayer, Marker, Popup, useMap } from "react-leaflet";
+import L from "leaflet";
+
+const courierIcon = L.divIcon({
+  className: "",
+  html: `<div style="position:relative;">
+    <svg width="36" height="36" viewBox="0 0 24 24" fill="none">
+      <circle cx="12" cy="12" r="11" fill="#ff6b35" stroke="#fff" stroke-width="2"/>
+      <path d="M7 15a2 2 0 100-4 2 2 0 000 4zm10 0a2 2 0 100-4 2 2 0 000 4z" fill="#fff"/>
+      <path d="M5 13h3l2-3h4l1 3h3" stroke="#fff" stroke-width="1.4" fill="none" stroke-linecap="round" stroke-linejoin="round"/>
+    </svg>
+  </div>`,
+  iconSize: [36, 36],
+  iconAnchor: [18, 18],
+});
+
+function Recenter({ center }: { center: [number, number] }) {
+  const map = useMap();
+  useEffect(() => {
+    map.setView(center, map.getZoom(), { animate: true });
+  }, [center, map]);
+  return null;
+}
+
+function InvalidateSize() {
+  const map = useMap();
+  useEffect(() => {
+    const t = setTimeout(() => map.invalidateSize(), 50);
+    const obs = new ResizeObserver(() => map.invalidateSize());
+    obs.observe(map.getContainer());
+    return () => {
+      clearTimeout(t);
+      obs.disconnect();
+    };
+  }, [map]);
+  return null;
+}
+
+interface LiveTrackingMapProps {
+  lat: number | null;
+  lng: number | null;
+  height?: string;
+  popupText?: string;
+}
+
+const defaultCenter: [number, number] = [4.6097, -74.0817];
+
+const LiveTrackingMap = ({ lat, lng, height = "420px", popupText = "Domiciliario" }: LiveTrackingMapProps) => {
+  const [mounted, setMounted] = useState(false);
+  useEffect(() => setMounted(true), []);
+
+  const hasPosition = lat !== null && lng !== null;
+  const center: [number, number] = hasPosition ? [lat as number, lng as number] : defaultCenter;
+
+  if (!mounted) {
+    return <div style={{ height, background: "#f0f0f0", borderRadius: "12px" }} />;
+  }
+
+  return (
+    <div style={{ height, borderRadius: "12px", overflow: "hidden", position: "relative" }}>
+      <MapContainer center={center} zoom={15} preferCanvas style={{ height: "100%", width: "100%" }}>
+        <InvalidateSize />
+        {hasPosition && <Recenter center={center} />}
+        <TileLayer url="https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png" />
+        {hasPosition && (
+          <Marker position={center} icon={courierIcon}>
+            <Popup>{popupText}</Popup>
+          </Marker>
+        )}
+      </MapContainer>
+    </div>
+  );
+};
+
+export default LiveTrackingMap;

--- a/Frontend/src/ui/components/layout/CourierLayout/CourierSidebar.tsx
+++ b/Frontend/src/ui/components/layout/CourierLayout/CourierSidebar.tsx
@@ -1,5 +1,5 @@
 import { Link, useLocation } from "react-router-dom";
-import { Home, User } from "lucide-react";
+import { Home, User, Bike } from "lucide-react";
 import "./CourierSidebar.css";
 
 const menuItems = [
@@ -7,6 +7,11 @@ const menuItems = [
     label: "Inicio",
     path: "/courier/dashboard",
     icon: <Home size={28} />,
+  },
+  {
+    label: "Mis Entregas",
+    path: "/courier/deliveries",
+    icon: <Bike size={28} />,
   },
   {
     label: "Mi Perfil",

--- a/Frontend/src/ui/hooks/useCourierBroadcast.ts
+++ b/Frontend/src/ui/hooks/useCourierBroadcast.ts
@@ -1,0 +1,117 @@
+import { useEffect, useMemo, useRef, useState } from "react";
+import { authLocalStorage } from "../../infrastructure/persistence/authLocalStorage";
+import { TrackingSocketGateway } from "../../infrastructure/socket/TrackingSocketGateway";
+import { SendCourierLocationUseCase } from "../../application/use-cases/SendCourierLocationUseCase";
+import type { LocationUpdateInput, TrackingConnectionState } from "../../domain/types/tracking.types";
+
+// El GPS de escritorio no "se mueve", así que reenviamos la última posición
+// periódicamente para mantener viva la clave en Redis (TTL 30s) y notificar al visor.
+const HEARTBEAT_MS = 10000;
+
+interface SentPoint {
+  lat: number;
+  lng: number;
+  timestamp: string;
+}
+
+/**
+ * Hook del EMISOR (domiciliario).
+ * Usa navigator.geolocation.watchPosition y manda cada lectura al backend por WebSocket.
+ */
+export function useCourierBroadcast(orderId: string | undefined) {
+  const gateway = useMemo(() => new TrackingSocketGateway(), []);
+  const sendLocationUseCase = useMemo(() => new SendCourierLocationUseCase(gateway), [gateway]);
+
+  const [broadcasting, setBroadcasting] = useState(false);
+  const [connectionState, setConnectionState] = useState<TrackingConnectionState>("idle");
+  const [lastSent, setLastSent] = useState<SentPoint | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const watchIdRef = useRef<number | null>(null);
+  const heartbeatRef = useRef<ReturnType<typeof setInterval> | null>(null);
+  const lastInputRef = useRef<LocationUpdateInput | null>(null);
+
+  const start = () => {
+    if (!orderId) {
+      setError("Falta el ID del pedido");
+      return;
+    }
+    if (!navigator.geolocation) {
+      setError("Tu navegador no soporta geolocalización");
+      return;
+    }
+
+    const token = authLocalStorage.getToken();
+    if (!token) {
+      setError("Sesión no encontrada");
+      return;
+    }
+
+    setError(null);
+    setConnectionState("connecting");
+
+    gateway.connect(token);
+    gateway.onConnectionChange((connected) =>
+      setConnectionState(connected ? "connected" : "disconnected"),
+    );
+    gateway.onError((data) => setError(data.message));
+
+    watchIdRef.current = navigator.geolocation.watchPosition(
+      (pos) => {
+        const { latitude, longitude, accuracy, speed, heading } = pos.coords;
+        const input: LocationUpdateInput = {
+          order_id: orderId,
+          lat: +latitude.toFixed(6),
+          lng: +longitude.toFixed(6),
+          accuracy: accuracy ?? undefined,
+          speed: speed != null ? Math.round(speed * 3.6) : undefined, // m/s → km/h
+          heading: heading ?? undefined,
+        };
+        lastInputRef.current = input;
+        sendLocationUseCase.execute(input);
+        setLastSent({ lat: input.lat, lng: input.lng, timestamp: new Date().toISOString() });
+      },
+      (err) => setError(`Error de GPS: ${err.message}`),
+      { enableHighAccuracy: true, maximumAge: 0, timeout: 10000 },
+    );
+
+    // Heartbeat: reenvía la última posición conocida para que Redis no expire
+    heartbeatRef.current = setInterval(() => {
+      if (lastInputRef.current) {
+        sendLocationUseCase.execute(lastInputRef.current);
+        setLastSent({
+          lat: lastInputRef.current.lat,
+          lng: lastInputRef.current.lng,
+          timestamp: new Date().toISOString(),
+        });
+      }
+    }, HEARTBEAT_MS);
+
+    setBroadcasting(true);
+  };
+
+  const stop = () => {
+    if (watchIdRef.current !== null) {
+      navigator.geolocation.clearWatch(watchIdRef.current);
+      watchIdRef.current = null;
+    }
+    if (heartbeatRef.current) {
+      clearInterval(heartbeatRef.current);
+      heartbeatRef.current = null;
+    }
+    gateway.disconnect();
+    setBroadcasting(false);
+    setConnectionState("idle");
+  };
+
+  useEffect(() => {
+    return () => {
+      if (watchIdRef.current !== null) navigator.geolocation.clearWatch(watchIdRef.current);
+      if (heartbeatRef.current) clearInterval(heartbeatRef.current);
+      gateway.disconnect();
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
+
+  return { broadcasting, connectionState, lastSent, error, start, stop };
+}

--- a/Frontend/src/ui/hooks/useOrderTracking.ts
+++ b/Frontend/src/ui/hooks/useOrderTracking.ts
@@ -1,0 +1,90 @@
+import { useEffect, useMemo, useRef, useState, useCallback } from "react";
+import { authLocalStorage } from "../../infrastructure/persistence/authLocalStorage";
+import { TrackingSocketGateway } from "../../infrastructure/socket/TrackingSocketGateway";
+import { TrackingRepositoryImpl } from "../../infrastructure/repositories/TrackingRepositoryImpl";
+import { SubscribeToOrderTrackingUseCase } from "../../application/use-cases/SubscribeToOrderTrackingUseCase";
+import { GetLastLocationUseCase } from "../../application/use-cases/GetLastLocationUseCase";
+import type { CourierLocation, TrackingConnectionState } from "../../domain/types/tracking.types";
+
+const REST_FALLBACK_INTERVAL = 8000; // ms — solo se usa si el WebSocket no está conectado
+
+/**
+ * Hook del VISOR (usuario/negocio/admin).
+ * Conecta al WebSocket, se suscribe al pedido y expone la ubicación en vivo.
+ * Si el WebSocket cae, hace polling al fallback REST.
+ */
+export function useOrderTracking(orderId: string | undefined) {
+  const gateway = useMemo(() => new TrackingSocketGateway(), []);
+  const subscribeUseCase = useMemo(() => new SubscribeToOrderTrackingUseCase(gateway), [gateway]);
+  const getLastLocationUseCase = useMemo(
+    () => new GetLastLocationUseCase(new TrackingRepositoryImpl()),
+    [],
+  );
+
+  const [location, setLocation] = useState<CourierLocation | null>(null);
+  const [status, setStatus] = useState<string | null>(null);
+  const [connectionState, setConnectionState] = useState<TrackingConnectionState>("idle");
+  const [closed, setClosed] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  const connectedRef = useRef(false);
+  const pollRef = useRef<ReturnType<typeof setInterval> | null>(null);
+
+  const fetchRest = useCallback(async () => {
+    if (!orderId) return;
+    try {
+      const data = await getLastLocationUseCase.execute(orderId);
+      setStatus(data.status);
+      if (data.location) setLocation(data.location);
+    } catch (e: any) {
+      setError(e?.response?.data?.message ?? "No se pudo obtener la ubicación");
+    }
+  }, [orderId, getLastLocationUseCase]);
+
+  useEffect(() => {
+    if (!orderId) return;
+    const token = authLocalStorage.getToken();
+    if (!token) {
+      setError("Sesión no encontrada");
+      return;
+    }
+
+    setConnectionState("connecting");
+
+    // Carga inicial vía REST (muestra última ubicación conocida al instante)
+    fetchRest();
+
+    // Conectar y registrar handlers ANTES de suscribir
+    gateway.connect(token);
+
+    gateway.onConnectionChange((connected) => {
+      connectedRef.current = connected;
+      setConnectionState(connected ? "connected" : "disconnected");
+    });
+    gateway.onLocation((loc) => {
+      setLocation(loc);
+      setStatus((prev) => prev ?? "IN_DELIVERY");
+    });
+    gateway.onTrackingClosed(() => {
+      setClosed(true);
+      setStatus("DELIVERED");
+    });
+    gateway.onError((data) => setError(data.message));
+
+    subscribeUseCase.execute(token, orderId);
+
+    // Fallback: si no hay conexión WS, refrescar por REST periódicamente
+    pollRef.current = setInterval(() => {
+      if (!connectedRef.current && !closed) fetchRest();
+    }, REST_FALLBACK_INTERVAL);
+
+    return () => {
+      if (pollRef.current) clearInterval(pollRef.current);
+      gateway.disconnect();
+      connectedRef.current = false;
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [orderId]);
+
+  return { location, status, connectionState, closed, error, refetch: fetchRest };
+}

--- a/Frontend/src/ui/pages/CourierDashboard/CourierDeliveries.css
+++ b/Frontend/src/ui/pages/CourierDashboard/CourierDeliveries.css
@@ -1,0 +1,94 @@
+.courier-deliveries {
+  padding: 8px 4px;
+}
+
+.courier-deliveries h1 {
+  font-size: 24px;
+  margin: 0;
+  color: #1f2937;
+}
+
+.courier-deliveries-subtitle {
+  color: #6b7280;
+  margin: 4px 0 20px;
+  font-size: 14px;
+}
+
+.courier-deliveries-loading,
+.courier-deliveries-empty {
+  text-align: center;
+  color: #9ca3af;
+  padding: 48px 0;
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 10px;
+}
+
+.courier-deliveries-list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(280px, 1fr));
+  gap: 16px;
+}
+
+.delivery-card {
+  background: #fff;
+  border: 1px solid #f0f0f0;
+  border-radius: 12px;
+  padding: 16px;
+  box-shadow: 0 1px 4px rgba(0, 0, 0, 0.06);
+}
+
+.delivery-card-top {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 12px;
+}
+
+.delivery-id {
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.delivery-status {
+  font-size: 12px;
+  font-weight: 700;
+  padding: 4px 10px;
+  border-radius: 999px;
+}
+
+.status-blue { background: #dbeafe; color: #1d4ed8; }
+.status-purple { background: #ede9fe; color: #7c3aed; }
+.status-gray { background: #f3f4f6; color: #6b7280; }
+
+.delivery-info {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: #4b5563;
+  margin: 6px 0;
+}
+
+.delivery-share-btn {
+  width: 100%;
+  margin-top: 14px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 8px;
+  background: #ff6b35;
+  color: #fff;
+  border: 0;
+  padding: 10px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 700;
+  cursor: pointer;
+  transition: background 0.2s;
+}
+
+.delivery-share-btn:hover {
+  background: #e85d2a;
+}

--- a/Frontend/src/ui/pages/CourierDashboard/CourierDeliveries.tsx
+++ b/Frontend/src/ui/pages/CourierDashboard/CourierDeliveries.tsx
@@ -1,0 +1,103 @@
+import { useEffect, useState, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
+import { MapPin, Package, Navigation, Clock } from "lucide-react";
+import CourierLayout from "../../components/layout/CourierLayout/CourierLayout";
+import { useAuth } from "../../context/useAuth";
+import { GetCourierOrdersUseCase } from "../../../application/use-cases/GetCourierOrdersUseCase";
+import { CourierOrdersRepositoryImpl } from "../../../infrastructure/repositories/CourierOrdersRepositoryImpl";
+import type { CourierOrder } from "../../../domain/types/courier-orders.types";
+import "./CourierDeliveries.css";
+
+const STATUS_LABEL: Record<string, { label: string; color: string }> = {
+  READY: { label: "Listo para recoger", color: "blue" },
+  IN_DELIVERY: { label: "En entrega", color: "purple" },
+  DELIVERED: { label: "Entregado", color: "gray" },
+};
+
+const CourierDeliveries = () => {
+  const navigate = useNavigate();
+  const { courierProfile, fetchCourierProfile } = useAuth();
+  const [orders, setOrders] = useState<CourierOrder[]>([]);
+  const [loading, setLoading] = useState(true);
+
+  const getCourierOrders = new GetCourierOrdersUseCase(new CourierOrdersRepositoryImpl());
+
+  useEffect(() => {
+    if (!courierProfile) fetchCourierProfile();
+  }, [courierProfile, fetchCourierProfile]);
+
+  const load = useCallback(async () => {
+    if (!courierProfile?.couriers_id) return;
+    try {
+      const data = await getCourierOrders.execute(courierProfile.couriers_id);
+      setOrders(data);
+    } catch (error) {
+      console.error("Error cargando entregas:", error);
+    } finally {
+      setLoading(false);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [courierProfile]);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  return (
+    <CourierLayout>
+      <div className="courier-deliveries">
+        <h1>Mis Entregas</h1>
+        <p className="courier-deliveries-subtitle">Pedidos asignados a ti</p>
+
+        {loading ? (
+          <div className="courier-deliveries-loading">Cargando entregas...</div>
+        ) : orders.length === 0 ? (
+          <div className="courier-deliveries-empty">
+            <Package size={40} />
+            <p>Aún no tienes entregas asignadas</p>
+          </div>
+        ) : (
+          <div className="courier-deliveries-list">
+            {orders.map((order) => {
+              const st = STATUS_LABEL[order.status] || { label: order.status, color: "gray" };
+              const isInDelivery = order.status === "IN_DELIVERY";
+
+              return (
+                <div key={order.order_id} className="delivery-card">
+                  <div className="delivery-card-top">
+                    <span className="delivery-id">#{order.order_id.slice(-6).toUpperCase()}</span>
+                    <span className={`delivery-status status-${st.color}`}>{st.label}</span>
+                  </div>
+
+                  <div className="delivery-info">
+                    <MapPin size={15} />
+                    <span>{order.delivery_address}</span>
+                  </div>
+                  <div className="delivery-info">
+                    <Package size={15} />
+                    <span>{order.items.length} producto(s)</span>
+                  </div>
+                  <div className="delivery-info">
+                    <Clock size={15} />
+                    <span>Domicilio: ${order.delivery_fee.toLocaleString()}</span>
+                  </div>
+
+                  {isInDelivery && (
+                    <button
+                      className="delivery-share-btn"
+                      onClick={() => navigate(`/courier/tracking/${order.order_id}`)}
+                    >
+                      <Navigation size={16} /> Compartir ubicación
+                    </button>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </CourierLayout>
+  );
+};
+
+export default CourierDeliveries;

--- a/Frontend/src/ui/pages/Tracking/CourierBroadcast.tsx
+++ b/Frontend/src/ui/pages/Tracking/CourierBroadcast.tsx
@@ -1,0 +1,64 @@
+import { useParams } from "react-router-dom";
+import { useCourierBroadcast } from "../../hooks/useCourierBroadcast";
+import LiveTrackingMap from "../../components/DeliveryMap/LiveTrackingMap";
+import "./Tracking.css";
+
+const CourierBroadcast = () => {
+  const { orderId } = useParams<{ orderId: string }>();
+  const { broadcasting, connectionState, lastSent, error, start, stop } = useCourierBroadcast(orderId);
+
+  const lastTime = lastSent ? new Date(lastSent.timestamp).toLocaleTimeString() : null;
+
+  return (
+    <div className="tracking-page">
+      <div className="tracking-header">
+        <div>
+          <h1>Compartir mi ubicación</h1>
+          <p className="tracking-order-id">Pedido #{orderId}</p>
+        </div>
+        <span className={`tracking-badge ${connectionState === "connected" ? "live" : "off"}`}>
+          <span className="tracking-dot" /> {broadcasting ? "Transmitiendo" : "Detenido"}
+        </span>
+      </div>
+
+      {error && <div className="tracking-banner error">⚠ {error}</div>}
+
+      <LiveTrackingMap
+        lat={lastSent?.lat ?? null}
+        lng={lastSent?.lng ?? null}
+        popupText="Tu posición actual"
+      />
+
+      <div className="tracking-actions">
+        {!broadcasting ? (
+          <button className="tracking-btn start" onClick={start}>
+            ▶ Iniciar transmisión GPS
+          </button>
+        ) : (
+          <button className="tracking-btn stop" onClick={stop}>
+            ⏸ Detener
+          </button>
+        )}
+      </div>
+
+      <div className="tracking-info">
+        <div className="tracking-info-item">
+          <span className="tracking-info-label">Última posición enviada</span>
+          <span className="tracking-info-value">
+            {lastSent ? `${lastSent.lat}, ${lastSent.lng}` : "—"}
+          </span>
+        </div>
+        <div className="tracking-info-item">
+          <span className="tracking-info-label">Hora</span>
+          <span className="tracking-info-value">{lastTime ?? "—"}</span>
+        </div>
+      </div>
+
+      <p className="tracking-waiting">
+        Mantén esta pantalla abierta mientras realizas la entrega. Tu ubicación se comparte con el cliente en tiempo real.
+      </p>
+    </div>
+  );
+};
+
+export default CourierBroadcast;

--- a/Frontend/src/ui/pages/Tracking/OrderTracking.tsx
+++ b/Frontend/src/ui/pages/Tracking/OrderTracking.tsx
@@ -1,0 +1,71 @@
+import { useParams } from "react-router-dom";
+import { useOrderTracking } from "../../hooks/useOrderTracking";
+import LiveTrackingMap from "../../components/DeliveryMap/LiveTrackingMap";
+import "./Tracking.css";
+
+const OrderTracking = () => {
+  const { orderId } = useParams<{ orderId: string }>();
+  const { location, status, connectionState, closed, error } = useOrderTracking(orderId);
+
+  const connLabel: Record<string, string> = {
+    idle: "Inactivo",
+    connecting: "Conectando…",
+    connected: "En vivo",
+    disconnected: "Reconectando…",
+    error: "Error",
+  };
+
+  const lastUpdate = location ? new Date(location.timestamp).toLocaleTimeString() : null;
+
+  return (
+    <div className="tracking-page">
+      <div className="tracking-header">
+        <div>
+          <h1>Seguimiento del pedido</h1>
+          <p className="tracking-order-id">#{orderId}</p>
+        </div>
+        <span className={`tracking-badge ${connectionState === "connected" ? "live" : "off"}`}>
+          <span className="tracking-dot" /> {connLabel[connectionState] ?? connectionState}
+        </span>
+      </div>
+
+      {closed && (
+        <div className="tracking-banner success">
+          🏁 El pedido fue entregado. Seguimiento finalizado.
+        </div>
+      )}
+      {error && !closed && <div className="tracking-banner error">⚠ {error}</div>}
+
+      <LiveTrackingMap
+        lat={location?.lat ?? null}
+        lng={location?.lng ?? null}
+        popupText="Tu domiciliario está aquí"
+      />
+
+      <div className="tracking-info">
+        <div className="tracking-info-item">
+          <span className="tracking-info-label">Estado del pedido</span>
+          <span className="tracking-info-value">{status ?? "—"}</span>
+        </div>
+        <div className="tracking-info-item">
+          <span className="tracking-info-label">Última actualización</span>
+          <span className="tracking-info-value">{lastUpdate ?? "Esperando ubicación…"}</span>
+        </div>
+        {location?.speed != null && (
+          <div className="tracking-info-item">
+            <span className="tracking-info-label">Velocidad</span>
+            <span className="tracking-info-value">{location.speed} km/h</span>
+          </div>
+        )}
+      </div>
+
+      {!location && !closed && (
+        <p className="tracking-waiting">
+          Aún no recibimos la ubicación del domiciliario. Aparecerá aquí en cuanto inicie la entrega.
+        </p>
+      )}
+    </div>
+  );
+};
+
+export default OrderTracking;

--- a/Frontend/src/ui/pages/Tracking/Tracking.css
+++ b/Frontend/src/ui/pages/Tracking/Tracking.css
@@ -1,0 +1,135 @@
+.tracking-page {
+  max-width: 760px;
+  margin: 0 auto;
+  padding: 24px 16px;
+}
+
+.tracking-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 16px;
+}
+
+.tracking-header h1 {
+  font-size: 22px;
+  margin: 0;
+  color: #1f2937;
+}
+
+.tracking-order-id {
+  margin: 2px 0 0;
+  color: #6b7280;
+  font-size: 13px;
+}
+
+.tracking-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 12px;
+  font-weight: 700;
+  padding: 5px 12px;
+  border-radius: 999px;
+}
+
+.tracking-badge.live {
+  background: #dcfce7;
+  color: #16a34a;
+}
+
+.tracking-badge.off {
+  background: #fef3c7;
+  color: #b45309;
+}
+
+.tracking-dot {
+  width: 8px;
+  height: 8px;
+  border-radius: 50%;
+  background: currentColor;
+  animation: tracking-pulse 1.4s infinite;
+}
+
+@keyframes tracking-pulse {
+  0%, 100% { opacity: 1; }
+  50% { opacity: 0.3; }
+}
+
+.tracking-banner {
+  padding: 12px 16px;
+  border-radius: 8px;
+  margin-bottom: 14px;
+  font-size: 14px;
+  font-weight: 600;
+}
+
+.tracking-banner.success {
+  background: #dcfce7;
+  color: #15803d;
+}
+
+.tracking-banner.error {
+  background: #fee2e2;
+  color: #b91c1c;
+}
+
+.tracking-info {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 12px;
+  margin-top: 16px;
+}
+
+.tracking-info-item {
+  background: #f9fafb;
+  border: 1px solid #f0f0f0;
+  border-radius: 10px;
+  padding: 12px 14px;
+}
+
+.tracking-info-label {
+  display: block;
+  font-size: 11px;
+  text-transform: uppercase;
+  color: #9ca3af;
+  letter-spacing: 0.04em;
+  margin-bottom: 4px;
+}
+
+.tracking-info-value {
+  font-size: 15px;
+  font-weight: 700;
+  color: #1f2937;
+}
+
+.tracking-waiting {
+  margin-top: 16px;
+  color: #6b7280;
+  font-size: 13px;
+  text-align: center;
+}
+
+.tracking-actions {
+  margin-top: 16px;
+  display: flex;
+  justify-content: center;
+}
+
+.tracking-btn {
+  border: 0;
+  border-radius: 10px;
+  padding: 12px 28px;
+  font-size: 15px;
+  font-weight: 700;
+  color: #fff;
+  cursor: pointer;
+}
+
+.tracking-btn.start {
+  background: #ff6b35;
+}
+
+.tracking-btn.stop {
+  background: #6b7280;
+}

--- a/Frontend/src/ui/pages/VendorDashboard/VendorOrders.css
+++ b/Frontend/src/ui/pages/VendorDashboard/VendorOrders.css
@@ -147,6 +147,26 @@
   background: #e0e0e0;
 }
 
+.track-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  background: #ff6b35;
+  border: none;
+  color: #fff;
+  padding: 8px 16px;
+  border-radius: 8px;
+  font-size: 14px;
+  font-weight: 600;
+  cursor: pointer;
+  transition: all 0.2s ease;
+  margin-left: 8px;
+}
+
+.track-btn:hover {
+  background: #e85d2a;
+}
+
 .order-secondary-info {
   display: flex;
   align-items: center;

--- a/Frontend/src/ui/pages/VendorDashboard/VendorOrders.tsx
+++ b/Frontend/src/ui/pages/VendorDashboard/VendorOrders.tsx
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from "react";
-import { Clock, User, Package } from "lucide-react";
+import { useNavigate } from "react-router-dom";
+import { Clock, User, Package, MapPin } from "lucide-react";
 import VendorLayout from "../../components/layout/VendorLayout/VendorLayout";
 import { useAuth } from "../../context/useAuth";
 import type { RecentOrder } from "../../../domain/types/recent-orders.types";
@@ -17,6 +18,7 @@ const STATUS_CONFIG: Record<string, { color: string; label: string; icon: string
 };
 
 const VendorOrders = () => {
+  const navigate = useNavigate();
   const { vendorProfile, getAllVendorOrders } = useAuth();
   const [orders, setOrders] = useState<RecentOrder[]>([]);
   const [loading, setLoading] = useState(true);
@@ -80,6 +82,7 @@ const VendorOrders = () => {
           {orders.map((order) => {
             const statusConfig = STATUS_CONFIG[order.status] || { color: 'gray', label: order.status, icon: '' };
             const isPending = order.status === 'PENDING';
+            const isInDelivery = order.status === 'IN_DELIVERY';
 
             return (
               <div key={order.order_id} className="vendor-order-item">
@@ -111,6 +114,15 @@ const VendorOrders = () => {
                   >
                     Detalles
                   </button>
+
+                  {isInDelivery && (
+                    <button
+                      className="track-btn"
+                      onClick={() => navigate(`/tracking/${order.order_id}`)}
+                    >
+                      <MapPin size={14} /> Ver seguimiento
+                    </button>
+                  )}
                 </div>
 
                 <div className="order-secondary-info">

--- a/Frontend/src/ui/router/AppRouter.tsx
+++ b/Frontend/src/ui/router/AppRouter.tsx
@@ -21,6 +21,9 @@ import VendorCategories from "../pages/VendorDashboard/VendorCategories";
 import VendorCourierRequests from "../pages/VendorDashboard/VendorCourierRequests";
 import CourierDashboard from "../pages/CourierDashboard/CourierDashboard";
 import CourierProfile from "../pages/CourierDashboard/CourierProfile";
+import CourierDeliveries from "../pages/CourierDashboard/CourierDeliveries";
+import OrderTracking from "../pages/Tracking/OrderTracking";
+import CourierBroadcast from "../pages/Tracking/CourierBroadcast";
 
 const AppRouter = () => {
   return (
@@ -148,6 +151,33 @@ const AppRouter = () => {
           element={
             <PrivateRoute allowedRoles={[3]}>
               <CourierProfile />
+            </PrivateRoute>
+          }
+        />
+        <Route
+          path="/courier/deliveries"
+          element={
+            <PrivateRoute allowedRoles={[3]}>
+              <CourierDeliveries />
+            </PrivateRoute>
+          }
+        />
+        {/* Domiciliario transmite su GPS durante la entrega */}
+        <Route
+          path="/courier/tracking/:orderId"
+          element={
+            <PrivateRoute allowedRoles={[3]}>
+              <CourierBroadcast />
+            </PrivateRoute>
+          }
+        />
+
+        {/* Seguimiento en vivo del pedido (usuario/negocio/admin autenticado) */}
+        <Route
+          path="/tracking/:orderId"
+          element={
+            <PrivateRoute>
+              <OrderTracking />
             </PrivateRoute>
           }
         />

--- a/backend/scripts/gps-test-client.html
+++ b/backend/scripts/gps-test-client.html
@@ -1,0 +1,186 @@
+<!DOCTYPE html>
+<html lang="es">
+<head>
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>UrbanRush — Test GPS Tracking</title>
+  <script src="https://cdn.socket.io/4.8.1/socket.io.min.js"></script>
+  <style>
+    * { box-sizing: border-box; font-family: system-ui, sans-serif; }
+    body { margin: 0; background: #f0f2f5; color: #222; padding: 16px; }
+    h1 { color: #ff6b35; text-align: center; margin: 0 0 4px; }
+    .sub { text-align: center; color: #777; margin: 0 0 20px; font-size: 14px; }
+    .config { background: #fff; border-radius: 10px; padding: 16px; max-width: 1000px; margin: 0 auto 16px; box-shadow: 0 1px 4px rgba(0,0,0,.08); }
+    .config label { display:block; font-size:12px; font-weight:600; color:#555; margin: 8px 0 2px; }
+    .config input { width:100%; padding:8px; border:1px solid #ccc; border-radius:6px; font-size:13px; }
+    .grid { display: grid; grid-template-columns: 1fr 1fr; gap: 16px; max-width: 1000px; margin: 0 auto; }
+    .panel { background:#fff; border-radius:10px; padding:16px; box-shadow:0 1px 4px rgba(0,0,0,.08); }
+    .panel h2 { margin:0 0 12px; font-size:16px; display:flex; align-items:center; gap:8px; }
+    .courier h2 { color:#2563eb; }
+    .viewer h2 { color:#16a34a; }
+    button { background:#ff6b35; color:#fff; border:0; padding:9px 14px; border-radius:6px; cursor:pointer; font-weight:600; font-size:13px; margin:4px 4px 4px 0; }
+    button.secondary { background:#6b7280; }
+    button:disabled { opacity:.5; cursor:not-allowed; }
+    .status { font-size:12px; padding:4px 8px; border-radius:12px; font-weight:600; }
+    .on { background:#dcfce7; color:#16a34a; }
+    .off { background:#fee2e2; color:#dc2626; }
+    .log { background:#0f172a; color:#86efac; font-family:monospace; font-size:11px; padding:10px; border-radius:6px; height:260px; overflow-y:auto; white-space:pre-wrap; margin-top:10px; }
+    .coords { font-size:13px; margin:4px 0; }
+    .map { height:160px; background:#e5e7eb; border-radius:6px; margin-top:8px; position:relative; overflow:hidden; }
+    .dot { position:absolute; width:14px; height:14px; background:#dc2626; border:2px solid #fff; border-radius:50%; transform:translate(-50%,-50%); transition: all .5s; box-shadow:0 0 0 4px rgba(220,38,38,.3); }
+    small { color:#999; }
+  </style>
+</head>
+<body>
+  <h1>🛰️ UrbanRush — Test GPS Tracking</h1>
+  <p class="sub">Cliente WebSocket para probar el rastreo en tiempo real (namespace <code>/tracking</code>)</p>
+
+  <div class="config">
+    <label>Servidor WebSocket</label>
+    <input id="server" value="http://localhost:3000" />
+    <div style="display:grid; grid-template-columns:1fr 1fr; gap:12px;">
+      <div>
+        <label>Order ID (debe estar IN_DELIVERY)</label>
+        <input id="orderId" placeholder="ej: 6a29d7f8..." />
+      </div>
+    </div>
+  </div>
+
+  <div class="grid">
+    <!-- COURIER -->
+    <div class="panel courier">
+      <h2>🏍️ Domiciliario <span id="cStatus" class="status off">desconectado</span></h2>
+      <label style="font-size:12px;font-weight:600;color:#555;">Token JWT del DOMICILIARIO</label>
+      <input id="cToken" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:6px;font-size:11px;" placeholder="Bearer token del courier" />
+      <div style="margin-top:10px;">
+        <button id="cConnect">Conectar</button>
+        <button id="cStart" class="secondary" disabled>▶ Enviar ubicación (auto)</button>
+        <button id="cStop" class="secondary" disabled>⏸ Detener</button>
+      </div>
+      <div class="coords">📍 Última enviada: <span id="cCoords">—</span></div>
+      <small>Simula movimiento alrededor de Bogotá enviando cada 3s.</small>
+      <div class="log" id="cLog"></div>
+    </div>
+
+    <!-- VIEWER -->
+    <div class="panel viewer">
+      <h2>👤 Usuario (recibe) <span id="vStatus" class="status off">desconectado</span></h2>
+      <label style="font-size:12px;font-weight:600;color:#555;">Token JWT del USUARIO (dueño del pedido)</label>
+      <input id="vToken" style="width:100%;padding:8px;border:1px solid #ccc;border-radius:6px;font-size:11px;" placeholder="Bearer token del user" />
+      <div style="margin-top:10px;">
+        <button id="vConnect">Conectar</button>
+        <button id="vSubscribe" class="secondary" disabled>🔔 Suscribirse al tracking</button>
+      </div>
+      <div class="coords">📍 Ubicación recibida: <span id="vCoords">—</span></div>
+      <div class="map" id="vMap"><div class="dot" id="vDot" style="display:none;"></div></div>
+      <div class="log" id="vLog"></div>
+    </div>
+  </div>
+
+<script>
+  const $ = (id) => document.getElementById(id);
+  const now = () => new Date().toLocaleTimeString();
+  function log(el, msg, color) {
+    const line = document.createElement('div');
+    if (color) line.style.color = color;
+    line.textContent = `[${now()}] ${msg}`;
+    el.appendChild(line);
+    el.scrollTop = el.scrollHeight;
+  }
+
+  let courierSocket = null, viewerSocket = null, sendTimer = null;
+  // Punto base: Bogotá
+  let baseLat = 4.6489, baseLng = -74.0635, step = 0;
+
+  // ─── DOMICILIARIO ───
+  $('cConnect').onclick = () => {
+    const server = $('server').value.trim();
+    const token = $('cToken').value.trim().replace('Bearer ', '');
+    if (!token) return alert('Pega el token del domiciliario');
+
+    courierSocket = io(`${server}/tracking`, { auth: { token }, transports: ['websocket'] });
+
+    courierSocket.on('connect', () => {
+      $('cStatus').textContent = 'conectado'; $('cStatus').className = 'status on';
+      $('cStart').disabled = false;
+      log($('cLog'), '✓ Conectado al servidor', '#86efac');
+    });
+    courierSocket.on('disconnect', () => {
+      $('cStatus').textContent = 'desconectado'; $('cStatus').className = 'status off';
+      $('cStart').disabled = true; $('cStop').disabled = true;
+      log($('cLog'), '✗ Desconectado', '#fca5a5');
+    });
+    courierSocket.on('error', (e) => log($('cLog'), '⚠ ERROR: ' + JSON.stringify(e), '#fca5a5'));
+    courierSocket.on('location:saved', (d) => log($('cLog'), '✓ Guardada: ' + JSON.stringify(d), '#86efac'));
+    courierSocket.on('tracking:closed', (d) => log($('cLog'), '🏁 ' + d.message, '#fbbf24'));
+  };
+
+  $('cStart').onclick = () => {
+    const orderId = $('orderId').value.trim();
+    if (!orderId) return alert('Escribe el Order ID arriba');
+    $('cStart').disabled = true; $('cStop').disabled = false;
+
+    const sendOne = () => {
+      step++;
+      // Pequeño movimiento simulado
+      const lat = baseLat + Math.sin(step / 5) * 0.002 + step * 0.0001;
+      const lng = baseLng + Math.cos(step / 5) * 0.002 + step * 0.0001;
+      const payload = { order_id: orderId, lat: +lat.toFixed(6), lng: +lng.toFixed(6), accuracy: 12, speed: 18, heading: (step * 10) % 360 };
+      courierSocket.emit('courier:location:update', payload);
+      $('cCoords').textContent = `${payload.lat}, ${payload.lng}`;
+      log($('cLog'), '→ Enviando: ' + payload.lat + ', ' + payload.lng);
+    };
+    sendOne();
+    sendTimer = setInterval(sendOne, 3000);
+  };
+
+  $('cStop').onclick = () => {
+    clearInterval(sendTimer);
+    $('cStart').disabled = false; $('cStop').disabled = true;
+    log($('cLog'), '⏸ Envío detenido', '#fbbf24');
+  };
+
+  // ─── USUARIO (VIEWER) ───
+  $('vConnect').onclick = () => {
+    const server = $('server').value.trim();
+    const token = $('vToken').value.trim().replace('Bearer ', '');
+    if (!token) return alert('Pega el token del usuario');
+
+    viewerSocket = io(`${server}/tracking`, { auth: { token }, transports: ['websocket'] });
+
+    viewerSocket.on('connect', () => {
+      $('vStatus').textContent = 'conectado'; $('vStatus').className = 'status on';
+      $('vSubscribe').disabled = false;
+      log($('vLog'), '✓ Conectado al servidor', '#86efac');
+    });
+    viewerSocket.on('disconnect', () => {
+      $('vStatus').textContent = 'desconectado'; $('vStatus').className = 'status off';
+      $('vSubscribe').disabled = true;
+      log($('vLog'), '✗ Desconectado', '#fca5a5');
+    });
+    viewerSocket.on('error', (e) => log($('vLog'), '⚠ ERROR: ' + JSON.stringify(e), '#fca5a5'));
+    viewerSocket.on('tracking:subscribed', (d) => log($('vLog'), '🔔 Suscrito: ' + JSON.stringify(d), '#86efac'));
+    viewerSocket.on('tracking:closed', (d) => log($('vLog'), '🏁 ' + d.message, '#fbbf24'));
+
+    viewerSocket.on('courier:location', (d) => {
+      $('vCoords').textContent = `${d.lat}, ${d.lng} (vel: ${d.speed ?? '—'} km/h)`;
+      log($('vLog'), '📍 RECIBIDO: ' + d.lat + ', ' + d.lng, '#7dd3fc');
+      // Pintar punto en el "mapa" relativo
+      const dot = $('vDot');
+      dot.style.display = 'block';
+      const x = 50 + (d.lng - baseLng) * 8000;
+      const y = 50 - (d.lat - baseLat) * 8000;
+      dot.style.left = Math.max(5, Math.min(95, x)) + '%';
+      dot.style.top = Math.max(5, Math.min(95, y)) + '%';
+    });
+  };
+
+  $('vSubscribe').onclick = () => {
+    const orderId = $('orderId').value.trim();
+    if (!orderId) return alert('Escribe el Order ID arriba');
+    viewerSocket.emit('order:tracking', { order_id: orderId });
+    log($('vLog'), '→ Suscribiéndose a order ' + orderId);
+  };
+</script>
+</body>
+</html>

--- a/backend/scripts/seed-tracking-order.ts
+++ b/backend/scripts/seed-tracking-order.ts
@@ -1,0 +1,117 @@
+import 'dotenv/config';
+import { DataSource } from 'typeorm';
+import { MongoClient } from 'mongodb';
+import * as bcrypt from 'bcrypt';
+
+const COURIER_EMAIL = 'courier1@test.com';
+const CLIENT_EMAIL = 'cliente1@test.com';
+const PASSWORD = 'test1234';
+const VENDOR_ID = Number(process.argv[2] ?? 2); // vendor existente
+
+async function ensureRole(pg: DataSource, rolId: number, name: string) {
+  const r = await pg.query('SELECT rol_id FROM rol WHERE rol_id = $1', [rolId]);
+  if (r.length === 0) {
+    await pg.query('INSERT INTO rol (rol_id, rol_name) VALUES ($1, $2)', [rolId, name]);
+  }
+}
+
+async function ensureUser(pg: DataSource, email: string, rolId: number): Promise<number> {
+  const existing = await pg.query('SELECT user_id FROM users WHERE user_email = $1', [email]);
+  let userId: number;
+  if (existing.length > 0) {
+    userId = existing[0].user_id;
+  } else {
+    const hash = await bcrypt.hash(PASSWORD, 10);
+    const ins = await pg.query(
+      'INSERT INTO users (user_email, user_password, status) VALUES ($1, $2, true) RETURNING user_id',
+      [email, hash],
+    );
+    userId = ins[0].user_id;
+  }
+  // persona
+  const p = await pg.query('SELECT people_id FROM people WHERE user_id = $1', [userId]);
+  if (p.length === 0) {
+    await pg.query(
+      `INSERT INTO people ("firstName", "firstLastName", cellphone, address, gender, user_id)
+       VALUES ('Test', 'User', '3000000000', 'Calle 1', 'M', $1)`,
+      [userId],
+    );
+  }
+  // rol
+  const ur = await pg.query('SELECT * FROM userroles WHERE user_id = $1 AND rol_id = $2', [userId, rolId]);
+  if (ur.length === 0) {
+    await pg.query('INSERT INTO userroles (user_id, rol_id) VALUES ($1, $2)', [userId, rolId]);
+  }
+  return userId;
+}
+
+async function main() {
+  const pg = new DataSource({
+    type: 'postgres',
+    host: process.env.DB_HOST,
+    port: Number(process.env.DB_PORT ?? 5432),
+    username: process.env.DB_USER,
+    password: process.env.DB_PASSWORD,
+    database: process.env.DB_DATABASE,
+  });
+  await pg.initialize();
+
+  await ensureRole(pg, 2, 'USER');
+  await ensureRole(pg, 3, 'DOMICILIARIO');
+
+  // 1) Cliente (USER)
+  const clientUserId = await ensureUser(pg, CLIENT_EMAIL, 2);
+
+  // 2) Domiciliario (DOMICILIARIO) + fila en couriers
+  const courierUserId = await ensureUser(pg, COURIER_EMAIL, 3);
+  let courierRow = await pg.query('SELECT couriers_id FROM couriers WHERE user_id = $1', [courierUserId]);
+  let couriersId: number;
+  if (courierRow.length === 0) {
+    const ins = await pg.query(
+      `INSERT INTO couriers (vehicle_type, vehicle_plate, soat_number, status, user_id)
+       VALUES ('Moto', 'TST-001', 'SOAT-001', 'ACTIVE', $1) RETURNING couriers_id`,
+      [courierUserId],
+    );
+    couriersId = ins[0].couriers_id;
+  } else {
+    couriersId = courierRow[0].couriers_id;
+  }
+
+  await pg.destroy();
+
+  // 3) Pedido IN_DELIVERY en MongoDB
+  const mongoUri = process.env.MONGO_URI ?? 'mongodb://localhost:27017/urbanrush';
+  const mongo = new MongoClient(mongoUri);
+  await mongo.connect();
+  const db = mongo.db();
+
+  const result = await db.collection('orders').insertOne({
+    user_id: clientUserId,
+    vendor_id: VENDOR_ID,
+    courier_id: couriersId,
+    status: 'IN_DELIVERY',
+    delivery_address: 'Calle 100 # 15-20, Bogotá',
+    subtotal: 50000,
+    delivery_fee: 3000,
+    platform_commission: 7500,
+    total: 60500,
+    items: [{ product_id: 'p1', product_name: 'Combo', quantity: 1, unit_price: 50000 }],
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+  await mongo.close();
+
+  console.log('\n========================================');
+  console.log('✓ Escenario de tracking listo');
+  console.log('----------------------------------------');
+  console.log(`Order ID (IN_DELIVERY):  ${result.insertedId}`);
+  console.log(`courier_id asignado:     ${couriersId}`);
+  console.log('');
+  console.log('CREDENCIALES:');
+  console.log(`  Domiciliario → ${COURIER_EMAIL} / ${PASSWORD}`);
+  console.log(`  Cliente      → ${CLIENT_EMAIL} / ${PASSWORD}`);
+  console.log('========================================\n');
+  console.log('Pega ese Order ID en el cliente HTML y haz login con cada usuario para sacar sus tokens.');
+}
+
+main().catch((e) => { console.error(e); process.exit(1); });

--- a/backend/src/app.module.ts
+++ b/backend/src/app.module.ts
@@ -30,6 +30,7 @@ import { CategoryModule } from './category/category.module';
 import { VendorPhotosModule } from './vendor-photos/vendor-photos.module';
 import { CourierVendorRequestModule } from './courier-vendor-request/courier-vendor-request.module';
 import { LiquidationModule } from './liquidation/liquidation.module';
+import { TrackingModule } from './tracking/tracking.module';
 
 
 @Module({
@@ -89,6 +90,7 @@ import { LiquidationModule } from './liquidation/liquidation.module';
     VendorPhotosModule,
     CourierVendorRequestModule,
     LiquidationModule,
+    TrackingModule,
   ],
 })
 export class AppModule {}

--- a/backend/src/order/application/use-cases/get-orders-by-courier.use-case.ts
+++ b/backend/src/order/application/use-cases/get-orders-by-courier.use-case.ts
@@ -1,0 +1,8 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { IOrderRepository } from '../../domain/repositories/order.repository.interface';
+
+@Injectable()
+export class GetOrdersByCourierUseCase {
+  constructor(@Inject('IOrderRepository') private readonly orderRepository: IOrderRepository) {}
+  async execute(courierId: number) { return this.orderRepository.findByCourier(courierId); }
+}

--- a/backend/src/order/application/use-cases/update-order-status.use-case.ts
+++ b/backend/src/order/application/use-cases/update-order-status.use-case.ts
@@ -1,6 +1,8 @@
 import { Injectable, Inject, NotFoundException, BadRequestException } from '@nestjs/common';
 import { IOrderRepository } from '../../domain/repositories/order.repository.interface';
 import { RegisterCourierEarningUseCase } from 'src/liquidation/application/use-cases/register-courier-earning.use-case';
+import { IGPSRepository } from 'src/tracking/domain/repositories/gps.repository.interface';
+import { GPSGateway } from 'src/tracking/infrastructure/gateways/gps.gateway';
 
 const VALID_TRANSITIONS: Record<string, string[]> = {
   PENDING:     ['ACCEPTED', 'CANCELLED'],
@@ -15,6 +17,8 @@ export class UpdateOrderStatusUseCase {
   constructor(
     @Inject('IOrderRepository') private readonly orderRepository: IOrderRepository,
     private readonly registerCourierEarning: RegisterCourierEarningUseCase,
+    @Inject('IGPSRepository') private readonly gpsRepo: IGPSRepository,
+    private readonly gpsGateway: GPSGateway,
   ) {}
 
   async execute(orderId: string, newStatus: string, courierId?: number) {
@@ -30,6 +34,12 @@ export class UpdateOrderStatusUseCase {
 
     if (newStatus === 'DELIVERED') {
       await this.registerCourierEarning.execute(orderId);
+
+      const finalCourierId = courierId ?? order.courier_id;
+      if (finalCourierId !== null && finalCourierId !== undefined) {
+        await this.gpsRepo.deleteLocation(finalCourierId);
+      }
+      this.gpsGateway.closeTrackingRoom(orderId);
     }
 
     return updated;

--- a/backend/src/order/domain/repositories/order.repository.interface.ts
+++ b/backend/src/order/domain/repositories/order.repository.interface.ts
@@ -5,6 +5,7 @@ export interface IOrderRepository {
   findById(id: string): Promise<OrderModel | null>;
   findByUser(userId: number): Promise<OrderModel[]>;
   findByVendor(vendorId: number): Promise<OrderModel[]>;
+  findByCourier(courierId: number): Promise<OrderModel[]>;
   findAvailableForCourier(): Promise<OrderModel[]>;
   updateStatus(id: string, status: string, courierId?: number): Promise<OrderModel | null>;
 }

--- a/backend/src/order/infrastructure/controllers/order.controller.ts
+++ b/backend/src/order/infrastructure/controllers/order.controller.ts
@@ -7,6 +7,7 @@ import { CreateOrderUseCase } from '../../application/use-cases/create-order.use
 import { GetOrdersByUserUseCase } from '../../application/use-cases/get-orders-by-user.use-case';
 import { GetOrdersByVendorUseCase } from '../../application/use-cases/get-orders-by-vendor.use-case';
 import { GetAvailableOrdersUseCase } from '../../application/use-cases/get-available-orders.use-case';
+import { GetOrdersByCourierUseCase } from '../../application/use-cases/get-orders-by-courier.use-case';
 import { UpdateOrderStatusUseCase } from '../../application/use-cases/update-order-status.use-case';
 import { CreateOrderDto } from '../../application/dtos/create-order.dto';
 
@@ -20,6 +21,7 @@ export class OrderController {
     private readonly getByUser: GetOrdersByUserUseCase,
     private readonly getByVendor: GetOrdersByVendorUseCase,
     private readonly getAvailable: GetAvailableOrdersUseCase,
+    private readonly getByCourier: GetOrdersByCourierUseCase,
     private readonly updateStatus: UpdateOrderStatusUseCase,
   ) {}
 
@@ -53,6 +55,14 @@ export class OrderController {
   @ApiOperation({ summary: 'Pedidos disponibles para domiciliarios (READY)' })
   getAvailableOrders() {
     return this.getAvailable.execute();
+  }
+
+  // Domiciliario ve los pedidos asignados a él (sus entregas)
+  @Get('courier/:courierId')
+  @Roles(UserRole.DOMICILIARIO)
+  @ApiOperation({ summary: 'Pedidos asignados al domiciliario (sus entregas)' })
+  getByCourierId(@Param('courierId') courierId: string) {
+    return this.getByCourier.execute(Number(courierId));
   }
 
   // Vendor mueve: PENDING→ACCEPTED, ACCEPTED→PREPARING, PREPARING→READY

--- a/backend/src/order/infrastructure/repositories/mongo-order.repository.ts
+++ b/backend/src/order/infrastructure/repositories/mongo-order.repository.ts
@@ -51,6 +51,14 @@ export class MongoOrderRepository implements IOrderRepository {
     return docs.map(OrderMapper.toDomain);
   }
 
+  async findByCourier(courierId: number): Promise<OrderModel[]> {
+    const docs = await this.orderModel
+      .find({ courier_id: courierId })
+      .sort({ createdAt: -1 })
+      .exec();
+    return docs.map(OrderMapper.toDomain);
+  }
+
   async findAvailableForCourier(): Promise<OrderModel[]> {
     const docs = await this.orderModel
       .find({ status: 'READY' })

--- a/backend/src/order/order.module.ts
+++ b/backend/src/order/order.module.ts
@@ -6,16 +6,19 @@ import { CreateOrderUseCase } from './application/use-cases/create-order.use-cas
 import { GetOrdersByUserUseCase } from './application/use-cases/get-orders-by-user.use-case';
 import { GetOrdersByVendorUseCase } from './application/use-cases/get-orders-by-vendor.use-case';
 import { GetAvailableOrdersUseCase } from './application/use-cases/get-available-orders.use-case';
+import { GetOrdersByCourierUseCase } from './application/use-cases/get-orders-by-courier.use-case';
 import { UpdateOrderStatusUseCase } from './application/use-cases/update-order-status.use-case';
 import { OrderController } from './infrastructure/controllers/order.controller';
 import { ProductModule } from 'src/product/product.module';
 import { LiquidationModule } from 'src/liquidation/liquidation.module';
+import { TrackingModule } from 'src/tracking/tracking.module';
 
 @Module({
   imports: [
     MongooseModule.forFeature([{ name: Order.name, schema: OrderSchema }]),
     ProductModule,
     forwardRef(() => LiquidationModule),
+    forwardRef(() => TrackingModule),
   ],
   controllers: [OrderController],
   providers: [
@@ -25,6 +28,7 @@ import { LiquidationModule } from 'src/liquidation/liquidation.module';
     GetOrdersByUserUseCase,
     GetOrdersByVendorUseCase,
     GetAvailableOrdersUseCase,
+    GetOrdersByCourierUseCase,
     UpdateOrderStatusUseCase,
   ],
   exports: ['IOrderRepository'],

--- a/backend/src/tracking/application/dtos/update-location.dto.ts
+++ b/backend/src/tracking/application/dtos/update-location.dto.ts
@@ -1,0 +1,32 @@
+import { IsNumber, IsOptional, IsString, Min, Max } from 'class-validator';
+import { ApiProperty, ApiPropertyOptional } from '@nestjs/swagger';
+
+export class UpdateLocationDto {
+  @ApiProperty({ example: 'abc123' })
+  @IsString()
+  order_id: string;
+
+  @ApiProperty({ example: 4.6489, description: 'Latitud (-90 a 90)' })
+  @IsNumber()
+  @Min(-90)
+  @Max(90)
+  lat: number;
+
+  @ApiProperty({ example: -74.0635, description: 'Longitud (-180 a 180)' })
+  @IsNumber()
+  @Min(-180)
+  @Max(180)
+  lng: number;
+
+  @ApiPropertyOptional({ example: 15, description: 'Precisión en metros' })
+  @IsOptional() @IsNumber()
+  accuracy?: number;
+
+  @ApiPropertyOptional({ example: 20, description: 'Velocidad en km/h' })
+  @IsOptional() @IsNumber()
+  speed?: number;
+
+  @ApiPropertyOptional({ example: 180, description: 'Dirección 0-360 grados' })
+  @IsOptional() @IsNumber() @Min(0) @Max(360)
+  heading?: number;
+}

--- a/backend/src/tracking/application/use-cases/get-courier-location.use-case.ts
+++ b/backend/src/tracking/application/use-cases/get-courier-location.use-case.ts
@@ -1,0 +1,49 @@
+import { Injectable, Inject, NotFoundException, ForbiddenException } from '@nestjs/common';
+import { IGPSRepository } from '../../domain/repositories/gps.repository.interface';
+import { IOrderRepository } from 'src/order/domain/repositories/order.repository.interface';
+import { CourierLocationModel } from '../../domain/entities/courier-location.model';
+
+@Injectable()
+export class GetCourierLocationUseCase {
+  constructor(
+    @Inject('IGPSRepository')
+    private readonly gpsRepo: IGPSRepository,
+    @Inject('IOrderRepository')
+    private readonly orderRepo: IOrderRepository,
+  ) {}
+
+  async executeByOrder(orderId: string, requesterUserId: number, requesterRolIds: number[]): Promise<{
+    order_id: string;
+    courier_id: number | null;
+    status: string;
+    location: CourierLocationModel | null;
+  }> {
+    const order = await this.orderRepo.findById(orderId);
+    if (!order) throw new NotFoundException('Pedido no encontrado');
+
+    const isAdmin = requesterRolIds.includes(1) || requesterRolIds.includes(5);
+    const isOwner = order.user_id === requesterUserId;
+    const isAssignedCourier =
+      requesterRolIds.includes(3) && order.courier_id !== null;
+
+    if (!isOwner && !isAssignedCourier && !isAdmin) {
+      throw new ForbiddenException('No autorizado a ver el tracking de este pedido');
+    }
+
+    if (order.courier_id === null) {
+      return { order_id: orderId, courier_id: null, status: order.status, location: null };
+    }
+
+    const location = await this.gpsRepo.getLocation(order.courier_id);
+    return {
+      order_id: orderId,
+      courier_id: order.courier_id,
+      status: order.status,
+      location,
+    };
+  }
+
+  async executeByCourier(courierId: number): Promise<CourierLocationModel | null> {
+    return this.gpsRepo.getLocation(courierId);
+  }
+}

--- a/backend/src/tracking/application/use-cases/update-location.use-case.ts
+++ b/backend/src/tracking/application/use-cases/update-location.use-case.ts
@@ -1,0 +1,54 @@
+import { Injectable, Inject, NotFoundException, BadRequestException, ForbiddenException } from '@nestjs/common';
+import { InjectRepository } from '@nestjs/typeorm';
+import { Repository } from 'typeorm';
+import { IGPSRepository } from '../../domain/repositories/gps.repository.interface';
+import { IOrderRepository } from 'src/order/domain/repositories/order.repository.interface';
+import { CourierLocationModel } from '../../domain/entities/courier-location.model';
+import { CourierEntity } from 'src/courier/infrastructure/persistence/entities/courier.entity';
+import { UpdateLocationDto } from '../dtos/update-location.dto';
+
+export const GPS_TTL_SECONDS = 30;
+
+@Injectable()
+export class UpdateLocationUseCase {
+  constructor(
+    @Inject('IGPSRepository')
+    private readonly gpsRepo: IGPSRepository,
+    @Inject('IOrderRepository')
+    private readonly orderRepo: IOrderRepository,
+    @InjectRepository(CourierEntity)
+    private readonly courierRepo: Repository<CourierEntity>,
+  ) {}
+
+  async execute(userId: number, dto: UpdateLocationDto): Promise<CourierLocationModel> {
+    const courier = await this.courierRepo.findOne({ where: { user_id: userId } });
+    if (!courier) {
+      throw new ForbiddenException('El usuario no es un domiciliario');
+    }
+
+    const order = await this.orderRepo.findById(dto.order_id);
+    if (!order) throw new NotFoundException('Pedido no encontrado');
+
+    if (order.courier_id !== courier.couriers_id) {
+      throw new ForbiddenException('Este pedido no está asignado a ti');
+    }
+
+    if (order.status !== 'IN_DELIVERY') {
+      throw new BadRequestException(`El pedido debe estar IN_DELIVERY (actual: ${order.status})`);
+    }
+
+    const location = new CourierLocationModel(
+      courier.couriers_id,
+      dto.order_id,
+      dto.lat,
+      dto.lng,
+      dto.accuracy ?? null,
+      dto.speed ?? null,
+      dto.heading ?? null,
+      new Date(),
+    );
+
+    await this.gpsRepo.saveLocation(location, GPS_TTL_SECONDS);
+    return location;
+  }
+}

--- a/backend/src/tracking/domain/entities/courier-location.model.ts
+++ b/backend/src/tracking/domain/entities/courier-location.model.ts
@@ -1,0 +1,12 @@
+export class CourierLocationModel {
+  constructor(
+    public readonly courier_id: number,
+    public readonly order_id: string,
+    public readonly lat: number,
+    public readonly lng: number,
+    public readonly accuracy: number | null,
+    public readonly speed: number | null,
+    public readonly heading: number | null,
+    public readonly timestamp: Date,
+  ) {}
+}

--- a/backend/src/tracking/domain/repositories/gps.repository.interface.ts
+++ b/backend/src/tracking/domain/repositories/gps.repository.interface.ts
@@ -1,0 +1,7 @@
+import { CourierLocationModel } from '../entities/courier-location.model';
+
+export interface IGPSRepository {
+  saveLocation(location: CourierLocationModel, ttlSeconds: number): Promise<void>;
+  getLocation(courierId: number): Promise<CourierLocationModel | null>;
+  deleteLocation(courierId: number): Promise<void>;
+}

--- a/backend/src/tracking/infrastructure/controllers/tracking.controller.ts
+++ b/backend/src/tracking/infrastructure/controllers/tracking.controller.ts
@@ -1,0 +1,27 @@
+import { Controller, Get, Param, Request, UseGuards } from '@nestjs/common';
+import { ApiTags, ApiBearerAuth, ApiOperation } from '@nestjs/swagger';
+import { JwtAuthGuard } from 'src/auth/infrastructure/guards/jwt-auth.guard';
+import { RolesGuard } from 'src/auth/infrastructure/guards/roles.guard';
+import { Roles, UserRole } from 'src/auth/infrastructure/decorators/roles.decorator';
+import { GetCourierLocationUseCase } from '../../application/use-cases/get-courier-location.use-case';
+
+@ApiTags('Tracking')
+@ApiBearerAuth()
+@UseGuards(JwtAuthGuard, RolesGuard)
+@Controller('tracking')
+export class TrackingController {
+  constructor(
+    private readonly getCourierLocation: GetCourierLocationUseCase,
+  ) {}
+
+  @Get('order/:orderId')
+  @Roles(UserRole.USER, UserRole.DOMICILIARIO, UserRole.BUSINESS, UserRole.ADMIN, UserRole.SUPERADMIN)
+  @ApiOperation({ summary: 'Última ubicación conocida del domiciliario (fallback REST)' })
+  getByOrder(@Param('orderId') orderId: string, @Request() req) {
+    return this.getCourierLocation.executeByOrder(
+      orderId,
+      req.user.user_id,
+      req.user.rolIds ?? [],
+    );
+  }
+}

--- a/backend/src/tracking/infrastructure/gateways/gps.gateway.ts
+++ b/backend/src/tracking/infrastructure/gateways/gps.gateway.ts
@@ -1,0 +1,174 @@
+import {
+  WebSocketGateway,
+  WebSocketServer,
+  SubscribeMessage,
+  OnGatewayConnection,
+  OnGatewayDisconnect,
+  ConnectedSocket,
+  MessageBody,
+} from '@nestjs/websockets';
+import { Logger, Inject } from '@nestjs/common';
+import { Server, Socket } from 'socket.io';
+import { JwtService } from '@nestjs/jwt';
+import { ConfigService } from '@nestjs/config';
+import { JWT_SECRET } from 'src/config/constants';
+import { UpdateLocationUseCase } from '../../application/use-cases/update-location.use-case';
+import { GetCourierLocationUseCase } from '../../application/use-cases/get-courier-location.use-case';
+import { IOrderRepository } from 'src/order/domain/repositories/order.repository.interface';
+import { UpdateLocationDto } from '../../application/dtos/update-location.dto';
+
+interface AuthSocket extends Socket {
+  user?: { user_id: number; user_email: string; rolIds: number[] };
+}
+
+@WebSocketGateway({
+  cors: { origin: '*', credentials: true },
+  namespace: '/tracking',
+})
+export class GPSGateway implements OnGatewayConnection, OnGatewayDisconnect {
+  @WebSocketServer()
+  server: Server;
+
+  private readonly logger = new Logger(GPSGateway.name);
+
+  constructor(
+    private readonly jwtService: JwtService,
+    private readonly configService: ConfigService,
+    private readonly updateLocation: UpdateLocationUseCase,
+    private readonly getCourierLocation: GetCourierLocationUseCase,
+    @Inject('IOrderRepository')
+    private readonly orderRepo: IOrderRepository,
+  ) {}
+
+  async handleConnection(client: AuthSocket) {
+    try {
+      const token =
+        client.handshake.auth?.token ||
+        client.handshake.headers?.authorization?.toString().replace('Bearer ', '');
+
+      if (!token) {
+        client.emit('error', { message: 'Token no proporcionado' });
+        client.disconnect();
+        return;
+      }
+
+      const secret = this.configService.get<string>(JWT_SECRET);
+      const payload = this.jwtService.verify(token, { secret });
+      client.user = {
+        user_id: payload.user_id,
+        user_email: payload.user_email,
+        rolIds: payload.rolIds,
+      };
+
+      this.logger.log(`Tracking conectado: ${client.user.user_email} (${client.id})`);
+    } catch {
+      client.emit('error', { message: 'Token inválido' });
+      client.disconnect();
+    }
+  }
+
+  handleDisconnect(client: AuthSocket) {
+    this.logger.log(`Tracking desconectado: ${client.user?.user_email ?? client.id}`);
+  }
+
+  // ─── Usuario / vendor / admin se suscribe al tracking de un pedido ───
+  @SubscribeMessage('order:tracking')
+  async handleSubscribe(
+    @ConnectedSocket() client: AuthSocket,
+    @MessageBody() data: { order_id: string },
+  ) {
+    if (!client.user) return;
+
+    try {
+      const order = await this.orderRepo.findById(data.order_id);
+      if (!order) {
+        client.emit('error', { message: 'Pedido no encontrado' });
+        return;
+      }
+
+      const isOwner = order.user_id === client.user.user_id;
+      const isAdmin = client.user.rolIds.includes(1) || client.user.rolIds.includes(5);
+      const isCourier = client.user.rolIds.includes(3);
+      const isBusiness = client.user.rolIds.includes(4);
+
+      if (!isOwner && !isAdmin && !isCourier && !isBusiness) {
+        client.emit('error', { message: 'No autorizado' });
+        return;
+      }
+
+      const room = this.trackingRoom(data.order_id);
+      client.join(room);
+
+      // Enviar última ubicación conocida al unirse
+      if (order.courier_id !== null) {
+        const lastLocation = await this.getCourierLocation.executeByCourier(order.courier_id);
+        if (lastLocation) {
+          client.emit('courier:location', {
+            order_id: data.order_id,
+            courier_id: lastLocation.courier_id,
+            lat: lastLocation.lat,
+            lng: lastLocation.lng,
+            accuracy: lastLocation.accuracy,
+            speed: lastLocation.speed,
+            heading: lastLocation.heading,
+            timestamp: lastLocation.timestamp,
+          });
+        }
+      }
+
+      client.emit('tracking:subscribed', { order_id: data.order_id, status: order.status });
+      this.logger.log(`${client.user.user_email} suscrito a ${room}`);
+    } catch (error: any) {
+      client.emit('error', { message: error.message });
+    }
+  }
+
+  // ─── Domiciliario envía su ubicación ───
+  @SubscribeMessage('courier:location:update')
+  async handleLocationUpdate(
+    @ConnectedSocket() client: AuthSocket,
+    @MessageBody() data: UpdateLocationDto,
+  ) {
+    if (!client.user) return;
+
+    if (!client.user.rolIds.includes(3)) {
+      client.emit('error', { message: 'Solo domiciliarios pueden enviar ubicación' });
+      return;
+    }
+
+    try {
+      const location = await this.updateLocation.execute(client.user.user_id, data);
+
+      const room = this.trackingRoom(data.order_id);
+      this.server.to(room).emit('courier:location', {
+        order_id: data.order_id,
+        courier_id: location.courier_id,
+        lat: location.lat,
+        lng: location.lng,
+        accuracy: location.accuracy,
+        speed: location.speed,
+        heading: location.heading,
+        timestamp: location.timestamp,
+      });
+
+      client.emit('location:saved', { ok: true, timestamp: location.timestamp });
+    } catch (error: any) {
+      client.emit('error', { message: error.message });
+    }
+  }
+
+  // ─── Llamado desde UpdateOrderStatusUseCase cuando llega a DELIVERED ───
+  closeTrackingRoom(orderId: string) {
+    const room = this.trackingRoom(orderId);
+    this.server.to(room).emit('tracking:closed', {
+      order_id: orderId,
+      message: 'El pedido fue entregado. Tracking finalizado.',
+    });
+    this.server.in(room).socketsLeave(room);
+    this.logger.log(`Tracking cerrado para pedido ${orderId}`);
+  }
+
+  private trackingRoom(orderId: string): string {
+    return `tracking_order_${orderId}`;
+  }
+}

--- a/backend/src/tracking/infrastructure/repositories/redis-gps.repository.ts
+++ b/backend/src/tracking/infrastructure/repositories/redis-gps.repository.ts
@@ -1,0 +1,50 @@
+import { Injectable, Inject } from '@nestjs/common';
+import { CACHE_MANAGER } from '@nestjs/cache-manager';
+import { Cache } from 'cache-manager';
+import { IGPSRepository } from '../../domain/repositories/gps.repository.interface';
+import { CourierLocationModel } from '../../domain/entities/courier-location.model';
+
+@Injectable()
+export class RedisGPSRepository implements IGPSRepository {
+  constructor(@Inject(CACHE_MANAGER) private readonly cacheManager: Cache) {}
+
+  private buildKey(courierId: number): string {
+    return `gps:courier:${courierId}`;
+  }
+
+  async saveLocation(location: CourierLocationModel, ttlSeconds: number): Promise<void> {
+    const key = this.buildKey(location.courier_id);
+    const payload = {
+      courier_id: location.courier_id,
+      order_id: location.order_id,
+      lat: location.lat,
+      lng: location.lng,
+      accuracy: location.accuracy,
+      speed: location.speed,
+      heading: location.heading,
+      timestamp: location.timestamp.toISOString(),
+    };
+    await this.cacheManager.set(key, JSON.stringify(payload), ttlSeconds * 1000);
+  }
+
+  async getLocation(courierId: number): Promise<CourierLocationModel | null> {
+    const raw = await this.cacheManager.get<string>(this.buildKey(courierId));
+    if (!raw) return null;
+
+    const data = typeof raw === 'string' ? JSON.parse(raw) : (raw as any);
+    return new CourierLocationModel(
+      data.courier_id,
+      data.order_id,
+      data.lat,
+      data.lng,
+      data.accuracy ?? null,
+      data.speed ?? null,
+      data.heading ?? null,
+      new Date(data.timestamp),
+    );
+  }
+
+  async deleteLocation(courierId: number): Promise<void> {
+    await this.cacheManager.del(this.buildKey(courierId));
+  }
+}

--- a/backend/src/tracking/tracking.module.ts
+++ b/backend/src/tracking/tracking.module.ts
@@ -1,0 +1,46 @@
+import { Module, forwardRef } from '@nestjs/common';
+import { TypeOrmModule } from '@nestjs/typeorm';
+import { JwtModule } from '@nestjs/jwt';
+import { CacheModule } from '@nestjs/cache-manager';
+import { ConfigModule, ConfigService } from '@nestjs/config';
+import * as redisStore from 'cache-manager-ioredis';
+import { JWT_SECRET } from 'src/config/constants';
+import { CourierEntity } from 'src/courier/infrastructure/persistence/entities/courier.entity';
+import { OrderModule } from 'src/order/order.module';
+import { RedisGPSRepository } from './infrastructure/repositories/redis-gps.repository';
+import { UpdateLocationUseCase } from './application/use-cases/update-location.use-case';
+import { GetCourierLocationUseCase } from './application/use-cases/get-courier-location.use-case';
+import { GPSGateway } from './infrastructure/gateways/gps.gateway';
+import { TrackingController } from './infrastructure/controllers/tracking.controller';
+
+@Module({
+  imports: [
+    TypeOrmModule.forFeature([CourierEntity]),
+    CacheModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        store: redisStore,
+        host: config.get('REDIS_HOST'),
+        port: config.get('REDIS_PORT'),
+      }),
+    }),
+    JwtModule.registerAsync({
+      imports: [ConfigModule],
+      inject: [ConfigService],
+      useFactory: (config: ConfigService) => ({
+        secret: config.get<string>(JWT_SECRET),
+      }),
+    }),
+    forwardRef(() => OrderModule),
+  ],
+  controllers: [TrackingController],
+  providers: [
+    { provide: 'IGPSRepository', useClass: RedisGPSRepository },
+    UpdateLocationUseCase,
+    GetCourierLocationUseCase,
+    GPSGateway,
+  ],
+  exports: [GPSGateway, GetCourierLocationUseCase, 'IGPSRepository'],
+})
+export class TrackingModule {}


### PR DESCRIPTION
## Resumen
Sistema de rastreo GPS en tiempo real de domiciliarios durante una entrega activa. Las coordenadas se guardan en Redis (TTL automatico de 30s) y se transmiten al usuario por WebSockets, con arquitectura hexagonal en backend y frontend.

## Backend
- Modulo `tracking/` hexagonal: dominio (CourierLocationModel, IGPSRepository), aplicacion (UpdateLocationUseCase, GetCourierLocationUseCase), infraestructura (RedisGPSRepository, GPSGateway, controller).
- WebSocket namespace `/tracking` protegido con JWT.
- Eventos: `courier:location:update` (domiciliario emite) y `order:tracking` (visor se suscribe).
- Ubicacion en Redis con clave `gps:courier:{id}` y TTL 30s renovable.
- `UpdateLocationUseCase` valida pedido `IN_DELIVERY` asignado al domiciliario.
- Fallback REST `GET /tracking/order/:orderId`.
- Al pasar a `DELIVERED`: limpia Redis y cierra la sala (`tracking:closed`).
- Nuevo endpoint `GET /orders/courier/:courierId` (entregas del domiciliario).

## Frontend
- Capa hexagonal: types, ITrackingRepository/ITrackingGateway, use-cases, TrackingRepositoryImpl, TrackingSocketGateway (socket.io-client).
- Hooks `useOrderTracking` (visor + polling REST de respaldo) y `useCourierBroadcast` (emisor con geolocation + heartbeat).
- `LiveTrackingMap` con marcador movil (leaflet).
- Paginas `OrderTracking` (/tracking/:orderId) y `CourierBroadcast` (/courier/tracking/:orderId).
- Pagina "Mis Entregas" (/courier/deliveries) con boton "Compartir ubicacion".
- Boton "Ver seguimiento" en pedidos IN_DELIVERY del vendor.

## Variables de entorno
No requiere nuevas. Reutiliza REDIS_HOST, REDIS_PORT, JWT_SECRET y VITE_API_URL.

## Como probar
1. Backend + Redis (Memurai) corriendo.
2. `backend/scripts/seed-tracking-order.ts` crea un pedido IN_DELIVERY con domiciliario y cliente de prueba.
3. Domiciliario: login -> Mis Entregas -> Compartir ubicacion (permite GPS).
4. Cliente/vendor: Ver seguimiento -> mapa en vivo.
5. Cliente WebSocket de prueba: `backend/scripts/gps-test-client.html`.

## Notas
- Se agrego `socket.io-client` en el frontend.
- Incluye scripts de seed para que el equipo pueda probar.