### PR TITLE
Correccion de ubicacion de pedidos al cliente

### DIFF
--- a/backend/src/order/application/use-cases/get-courier-active-orders.use-case.ts
+++ b/backend/src/order/application/use-cases/get-courier-active-orders.use-case.ts
@@ -40,8 +40,8 @@ export class GetCourierActiveOrdersUseCase {
           customer_name: customer ? `${customer.firstName} ${customer.firstLastName}` : 'Cliente',
           customer_phone: customer?.cellphone || null,
           delivery_address: order.delivery_address,
-          customer_lat: customer?.latitude || null,
-          customer_lng: customer?.longitude || null,
+          customer_lat: order.customer_lat ?? customer?.latitude ?? null,
+          customer_lng: order.customer_lng ?? customer?.longitude ?? null,
           status: order.status,
           total: order.total,
         };

--- a/backend/src/order/application/use-cases/get-orders-by-courier.use-case.ts
+++ b/backend/src/order/application/use-cases/get-orders-by-courier.use-case.ts
@@ -21,8 +21,8 @@ export class GetOrdersByCourierUseCase {
         
         return {
           ...order,
-          customer_lat: customer?.latitude || null,
-          customer_lng: customer?.longitude || null,
+          customer_lat: order.customer_lat ?? customer?.latitude ?? null,
+          customer_lng: order.customer_lng ?? customer?.longitude ?? null,
           customer_name: customer ? `${customer.firstName} ${customer.firstLastName}` : 'Cliente',
           customer_phone: customer?.cellphone || null,
         };


### PR DESCRIPTION
### Descripcion

Se arregló el backend para que cuando el domiciliario ve un pedido activo, la ubicación del cliente se lea primero de las coordenadas que el cliente eligió al hacer el pedido (checkout), y solo si esas no existen, se busquen en el perfil del cliente. Antes solo miraba el perfil, por eso saltaba la alerta aunque el cliente hubiera puesto su dirección al comprar.

### Fixes #108 