### PR TITLE
feat: mejoras visuales, explorar tiendas con rating/productos y modal…

### DIFF
--- a/Frontend/src/domain/types/store.types.ts
+++ b/Frontend/src/domain/types/store.types.ts
@@ -23,6 +23,8 @@ export interface Store {
   logo_url?: string | null;
   storefront_image_url?: string | null;
   business_hours?: string | null;
+  averageRating?: number;
+  productCount?: number;
 }
 
 export interface HeroBanner {

--- a/Frontend/src/ui/components/chat/ChatWindow.css
+++ b/Frontend/src/ui/components/chat/ChatWindow.css
@@ -134,6 +134,10 @@
   color: #fff;
   border-bottom-right-radius: 4px;
 }
+.chat-bubble-row.mine .chat-bubble-text,
+.chat-bubble-row.mine .chat-bubble-time {
+  color: #fff;
+}
 .chat-bubble-row.other .chat-bubble {
   background: #fff;
   color: #222;

--- a/Frontend/src/ui/components/chatbot/ChatbotWidget.css
+++ b/Frontend/src/ui/components/chatbot/ChatbotWidget.css
@@ -110,8 +110,8 @@
   border-bottom-right-radius: 4px;
 }
 .chatbot-msg.bot .chatbot-bubble {
-  background: #fff;
-  border: 1px solid #ececec;
+  background: #ff6a00;
+  color: #fff;
   border-bottom-left-radius: 4px;
 }
 .chatbot-typing {
@@ -135,9 +135,9 @@
   margin-top: 4px;
 }
 .chatbot-quick-btn {
-  background: #fff;
-  border: 1px solid #ff6a00;
-  color: #ff6a00;
+  background: #ff6a00;
+  border: none;
+  color: #fff;
   padding: 6px 10px;
   border-radius: 999px;
   font-size: 12px;
@@ -145,7 +145,7 @@
   cursor: pointer;
   transition: background 0.15s;
 }
-.chatbot-quick-btn:hover:not(:disabled) { background: #fff1e0; }
+.chatbot-quick-btn:hover:not(:disabled) { background: #e85d00; }
 .chatbot-quick-btn:disabled             { opacity: 0.5; cursor: not-allowed; }
 .chatbot-action-btn {
   background: #222;

--- a/Frontend/src/ui/components/layout/AdminLayout/AdminLayout.css
+++ b/Frontend/src/ui/components/layout/AdminLayout/AdminLayout.css
@@ -37,16 +37,17 @@
   display: flex;
   align-items: center;
   gap: 6px;
-  background: #fff;
-  border: 1px solid #e5e7eb;
+  background: #ff6a00;
+  border: none;
   border-radius: 9px;
   padding: 7px 13px;
   font-weight: 600;
-  color: #dc3545;
+  color: #fff;
   cursor: pointer;
+  transition: background 0.15s;
 }
 .admin-topbar-logout:hover {
-  background: #fff5f5;
+  background: #e85d00;
 }
 
 .admin-layout-main {

--- a/Frontend/src/ui/components/layout/AdminLayout/AdminSidebar.css
+++ b/Frontend/src/ui/components/layout/AdminLayout/AdminSidebar.css
@@ -35,7 +35,7 @@
 .admin-sidebar-badge {
   font-size: 0.68rem;
   font-weight: 700;
-  color: #ff8c00;
+  color: #fff;
   letter-spacing: 1px;
   text-transform: uppercase;
 }
@@ -56,7 +56,7 @@
   padding: 12px 20px;
   margin: 0 10px;
   border-radius: 12px;
-  color: #cfd2dc;
+  color: #fff;
   text-decoration: none;
   font-weight: 700;
   font-size: 15px;
@@ -98,6 +98,10 @@
   width: 32px;
   height: 32px;
   transition: transform 0.25s ease;
+}
+
+.admin-sidebar-link > span {
+  color: #fff;
 }
 
 .dark-mode-wrapper.dark-mode .admin-sidebar {

--- a/Frontend/src/ui/components/layout/AdminLayout/AdminSidebar.tsx
+++ b/Frontend/src/ui/components/layout/AdminLayout/AdminSidebar.tsx
@@ -34,8 +34,7 @@ const AdminSidebar = () => {
   return (
     <aside className="admin-sidebar">
       <div className="admin-sidebar-logo">
-        <img src="/Logo-png.png" alt="UrbanRush" className="admin-sidebar-logo-img" />
-        <h1>UrbanRush</h1>
+        <img src="/Logo-cor.png" alt="UrbanRush" className="admin-sidebar-logo-img" />
         <span className="admin-sidebar-badge">Panel Admin</span>
       </div>
 

--- a/Frontend/src/ui/components/ui/ProductDetailModal/ProductDetailModal.css
+++ b/Frontend/src/ui/components/ui/ProductDetailModal/ProductDetailModal.css
@@ -130,6 +130,16 @@
   gap: 12px;
   color: #6b7280;
 }
+.product-modal-field--clickable {
+  cursor: pointer;
+  transition: background 0.15s;
+  padding: 4px 6px;
+  margin: -4px -6px;
+  border-radius: 8px;
+}
+.product-modal-field--clickable:hover .product-modal-value {
+  color: #ff6a00;
+}
 
 .product-modal-field div {
   display: flex;

--- a/Frontend/src/ui/components/ui/ProductDetailModal/ProductDetailModal.tsx
+++ b/Frontend/src/ui/components/ui/ProductDetailModal/ProductDetailModal.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from "react";
+import { useNavigate } from "react-router-dom";
 import { X, Store, Package, ShoppingCart, CreditCard } from "lucide-react";
 import toast from "react-hot-toast";
 import { vendorsApi, type VendorListItem } from "../../../../infrastructure/api/vendorsApi";
@@ -14,6 +15,7 @@ interface ProductDetailModalProps {
 }
 
 const ProductDetailModal = ({ product, onClose }: ProductDetailModalProps) => {
+  const navigate = useNavigate();
   const { addItem } = useCart();
   const { openCart } = useCartDrawer();
   const [vendor, setVendor] = useState<VendorListItem | null>(null);
@@ -49,6 +51,11 @@ const ProductDetailModal = ({ product, onClose }: ProductDetailModalProps) => {
     onClose();
     openCart();
   }, [addItem, product, onClose, openCart]);
+
+  const handleGoToStore = useCallback(() => {
+    onClose();
+    navigate(`/store/${product.vendor_id}`);
+  }, [onClose, navigate, product.vendor_id]);
 
   return (
     <div className="product-modal-overlay" onClick={onClose}>
@@ -87,7 +94,7 @@ const ProductDetailModal = ({ product, onClose }: ProductDetailModalProps) => {
             <h3>Información del Producto</h3>
             <div className="product-modal-fields">
               {vendor && (
-                <div className="product-modal-field">
+                <div className="product-modal-field product-modal-field--clickable" onClick={handleGoToStore}>
                   <Store size={16} />
                   <div>
                     <span className="product-modal-label">Negocio</span>

--- a/Frontend/src/ui/components/ui/StoreCard/StoreCard.tsx
+++ b/Frontend/src/ui/components/ui/StoreCard/StoreCard.tsx
@@ -1,10 +1,11 @@
 import type { Store } from "../../../../domain/types/store.types";
 import { useFavorites } from "../../../context/useFavorites";
+import { Package, Store as StoreIcon } from "lucide-react";
 import "./StoreCard.css";
 
 interface StoreCardProps {
   store: Store;
-  variant?: "recommended" | "nearby";
+  variant?: "recommended" | "nearby" | "grid";
   onClick?: () => void;
 }
 
@@ -24,6 +25,62 @@ const StoreCard = ({ store, variant = "recommended", onClick }: StoreCardProps) 
     e.stopPropagation();
     toggle(store.id, store.name);
   };
+
+  if (variant === "grid") {
+    return (
+      <div
+        onClick={onClick}
+        className="store-card-rec"
+        style={{
+          width: '100%',
+          background: '#fff',
+          borderRadius: '16px',
+          boxShadow: '0 4px 16px rgba(0,0,0,0.08)',
+          overflow: 'hidden',
+          border: '1px solid #f0f0f0',
+          cursor: 'pointer',
+        }}
+      >
+        <div style={{ position: 'relative' }}>
+          <img src={store.image} alt={store.name} style={{ width: '100%', height: '150px', objectFit: 'cover', display: 'block' }} />
+          <span style={{
+            position: 'absolute', top: '10px', right: '10px',
+            background: 'rgba(0,0,0,0.6)', color: '#fff', borderRadius: '14px',
+            padding: '3px 9px', fontSize: '12px', fontWeight: 700,
+            display: 'flex', alignItems: 'center', gap: '3px',
+          }}>
+            <svg width="11" height="11" viewBox="0 0 10 10" fill="#ffb300"><polygon points="5,1 6.5,4 10,4.5 7.5,7 8.1,10.5 5,8.8 1.9,10.5 2.5,7 0,4.5 3.5,4"/></svg>
+            {store.averageRating ?? store.rating ?? 0}
+          </span>
+        </div>
+        <div style={{ padding: '12px 14px 14px' }}>
+          <div style={{ fontWeight: 800, fontSize: '15px', color: '#1a1a1a', marginBottom: '6px', whiteSpace: 'nowrap', overflow: 'hidden', textOverflow: 'ellipsis' }}>
+            {store.name}
+          </div>
+          <div style={{ display: 'flex', alignItems: 'center', gap: '6px', flexWrap: 'wrap', fontSize: '12.5px', color: '#777', fontWeight: 600 }}>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+              <svg width="12" height="12" viewBox="0 0 10 10" fill="#f59e0b"><polygon points="5,1 6.5,4 10,4.5 7.5,7 8.1,10.5 5,8.8 1.9,10.5 2.5,7 0,4.5 3.5,4"/></svg>
+              {store.averageRating ?? store.rating ?? 0}
+            </span>
+            <span style={{ color: '#ccc' }}>{'\u2022'}</span>
+            <span style={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+              <Package size={14} strokeWidth={2} />
+              {store.productCount ?? 0} productos
+            </span>
+            {store.business_type && (
+              <>
+                <span style={{ color: '#ccc' }}>{'\u2022'}</span>
+                <span style={{ display: 'flex', alignItems: 'center', gap: '3px' }}>
+                  <StoreIcon size={14} strokeWidth={2} />
+                  {store.business_type}
+                </span>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+    );
+  }
 
   if (variant === "nearby") {
     return (

--- a/Frontend/src/ui/pages/AdminDashboard/AdminCommon.css
+++ b/Frontend/src/ui/pages/AdminDashboard/AdminCommon.css
@@ -137,7 +137,7 @@
 .admin-chip.role-2 { background: #e0f2fe; color: #0369a1; }
 .admin-chip.role-3 { background: #fef3c7; color: #b45309; }
 .admin-chip.role-4 { background: #dcfce7; color: #15803d; }
-.admin-chip.role-5 { background: #fee2e2; color: #b91c1c; }
+.admin-chip.role-5 { background: #ff6a00; color: #fff; }
 .admin-chip.on { background: #dcfce7; color: #15803d; }
 .admin-chip.off { background: #f3f4f6; color: #6b7280; }
 
@@ -175,7 +175,7 @@
 }
 .admin-btn.primary { background: #ff6a00; color: #fff; }
 .admin-btn.ghost { background: #f1f3f5; color: #444; }
-.admin-btn.danger { background: #fde8e8; color: #c0392b; }
+.admin-btn.danger { background: #ff6a00; color: #fff; }
 .admin-btn:disabled { opacity: 0.6; cursor: not-allowed; }
 .admin-row-actions { display: flex; gap: 8px; }
 .admin-icon-btn {
@@ -187,7 +187,7 @@
   color: #555;
   display: inline-flex;
 }
-.admin-icon-btn.danger { color: #c0392b; border-color: #f3c0c0; }
+.admin-icon-btn.danger { background: #ff6a00; color: #fff; border-color: #ff6a00; }
 .admin-icon-btn:hover { background: #f7f8fa; }
 
 .admin-loading, .admin-empty {

--- a/Frontend/src/ui/pages/Stores/Stores.tsx
+++ b/Frontend/src/ui/pages/Stores/Stores.tsx
@@ -23,6 +23,8 @@ function mapVendorToStore(v: any): Store {
     logo_url: v.logo_url ?? null,
     storefront_image_url: v.storefront_image_url ?? null,
     business_hours: v.business_hours ?? null,
+    averageRating: v.average_rating ?? 0,
+    productCount: v.product_count ?? 0,
   };
 }
 
@@ -145,13 +147,13 @@ const Stores = () => {
         <div
           style={{
             display: 'grid',
-            gap: '18px',
-            gridTemplateColumns: 'repeat(auto-fit, minmax(280px, 1fr))',
+            gap: '16px',
+            gridTemplateColumns: 'repeat(4, 1fr)',
             justifyItems: 'center',
           }}
         >
           {filteredStores.map((store) => (
-            <StoreCard key={store.id} store={store} variant="recommended" onClick={() => navigate(`/store/${store.id}`)} />
+            <StoreCard key={store.id} store={store} variant="grid" onClick={() => navigate(`/store/${store.id}`)} />
           ))}
         </div>
       )}

--- a/backend/src/vendor/application/use-cases/get-all-vendors.use-case.ts
+++ b/backend/src/vendor/application/use-cases/get-all-vendors.use-case.ts
@@ -1,14 +1,40 @@
 import { Inject, Injectable } from '@nestjs/common';
 import { IVendorRepository } from '../../domain/repositories/vendor.repository';
+import { IProductRepository } from '../../../product/domain/repositories/product.repository.interface';
+import { IReviewRepository } from '../../../review/domain/repositories/review.repository.interface';
 
 @Injectable()
 export class GetAllVendorsUseCase {
   constructor(
     @Inject('IVendorRepository')
     private readonly vendorRepository: IVendorRepository,
+    @Inject('IProductRepository')
+    private readonly productRepository: IProductRepository,
+    @Inject('IReviewRepository')
+    private readonly reviewRepository: IReviewRepository,
   ) {}
 
   async execute() {
-    return this.vendorRepository.findAll();
+    const vendors = await this.vendorRepository.findAll();
+
+    const enriched = await Promise.all(
+      vendors.map(async (vendor) => {
+        const vendorId = vendor.vendor_id!;
+        const [products, reviewStats] = await Promise.all([
+          this.productRepository.findByVendor(vendorId),
+          this.reviewRepository.findStatsByVendorId(vendorId),
+        ]);
+
+        return {
+          ...vendor,
+          product_count: products.length,
+          average_rating: reviewStats.average_rating,
+          total_reviews: reviewStats.total_reviews,
+          rating_distribution: reviewStats.rating_distribution,
+        };
+      }),
+    );
+
+    return enriched;
   }
 }

--- a/backend/src/vendor/vendor.module.ts
+++ b/backend/src/vendor/vendor.module.ts
@@ -23,6 +23,7 @@ import { PeopleEntity } from '../people/infrastructure/persistence/entities/peop
 import { CourierVendorRequestEntity } from '../courier-vendor-request/infrastructure/persistence/entities/courier-vendor-request.entity';
 import { ReportsModule } from '../reports/reports.module';
 import { TrackingModule } from '../tracking/tracking.module';
+import { ProductModule } from '../product/product.module';
 import { ReviewModule } from '../review/review.module';
 import { VendorStatsListener } from './infrastructure/listeners/vendor-stats.listener';
 
@@ -33,6 +34,7 @@ import { VendorStatsListener } from './infrastructure/listeners/vendor-stats.lis
       { name: Order.name, schema: OrderSchema },
       { name: VendorPhoto.name, schema: VendorPhotoSchema },
     ]),
+    ProductModule,
     ReportsModule,
     forwardRef(() => TrackingModule),
     ReviewModule,


### PR DESCRIPTION
## Resumen

Cambios visuales y funcionales en el panel admin, chat, chatbot, modal de producto y explorar tiendas.

### 🔥 Correcciones visuales
- **Panel admin**: textos rojos cambiados a blanco sobre fondo sapote (sidebar, badges role-5, botones danger, logout)
- **Chat usuario↔domiciliario**: textos de hora y mensaje del usuario forzados a blanco
- **Chatbot Urby**: burbujas del bot y quick-reply buttons con fondo sapote y texto blanco

### 🔗 Modal de producto
- Nombre del negocio clickeable: cierra el modal y navega a `/store/:vendorId`
- Hover con color sapote en el texto

### 🏪 Explorar tiendas
- Grid cambiado de 3 a **4 columnas**
- Cada tarjeta muestra: ⭐ rating promedio, 📦 cantidad de productos, 🏪 tipo de negocio
- Nuevo variant `"grid"` en StoreCard (sin botón de favorito, ancho 100%)
- Backend: `GetAllVendorsUseCase` ahora inyecta `IProductRepository` e `IReviewRepository` para devolver `average_rating` y `product_count`