### PR TITLE
fix: verificar estado real de Wompi en lugar de hardcodear APPROVED

### DIFF
--- a/Frontend/src/domain/types/payment.types.ts
+++ b/Frontend/src/domain/types/payment.types.ts
@@ -25,4 +25,5 @@ export interface CreatePaymentRequest {
   customer_email: string;
   transaction_id?: string;
   reference?: string;
+  status?: PaymentStatus;
 }

--- a/Frontend/src/ui/pages/Payment/PaymentPage.tsx
+++ b/Frontend/src/ui/pages/Payment/PaymentPage.tsx
@@ -55,7 +55,7 @@ const PaymentPage = () => {
       } catch {
         // ignore polling errors
       }
-    }, 10000);
+    }, 5000);
   }, [orderId]);
 
   useEffect(() => {
@@ -187,6 +187,14 @@ const PaymentPage = () => {
 
       checkout.open(async (result: any) => {
         if (result?.transaction) {
+          const txStatus = result.transaction.status;
+
+          if (txStatus === 'DECLINED' || txStatus === 'ERROR' || txStatus === 'VOIDED') {
+            const failPayment = { status: txStatus, transaction_id: result.transaction.id } as any;
+            setPayment(failPayment);
+            return;
+          }
+
           try {
             const newPayment = await paymentApi.create({
               order_id: orderId,
@@ -194,11 +202,16 @@ const PaymentPage = () => {
               customer_email: user.email,
               transaction_id: result.transaction.id,
               reference,
+              status: txStatus === 'APPROVED' ? 'APPROVED' : undefined,
             });
+
+            if (txStatus === 'APPROVED') {
+              setPayment(newPayment);
+              toast.success("Pago exitoso");
+              return;
+            }
+
             setPayment(newPayment);
-            paymentApi.confirm(reference).catch(() => {
-              // Si la confirmación manual falla, el webhook lo hará
-            });
             toast.success("Pago iniciado");
             startPolling();
           } catch (err: unknown) {
@@ -449,7 +462,7 @@ const PaymentPage = () => {
           <>
             <div className="payment-refresh">
               <div className="payment-refresh-dot" />
-              Actualizando cada 10 segundos
+              Actualizando cada 5 segundos
             </div>
             <button className="payment-btn payment-btn-primary" onClick={handlePay} disabled={creatingPayment}>
               <ExternalLink size={18} /> Pagar ahora

--- a/backend/src/payment/application/dtos/create-payment.dto.ts
+++ b/backend/src/payment/application/dtos/create-payment.dto.ts
@@ -26,4 +26,9 @@ export class CreatePaymentDto {
   @IsOptional()
   @IsString()
   reference?: string;
+
+  @ApiPropertyOptional({ description: 'Estado del pago (APPROVED, DECLINED, etc., si el widget ya lo conoce)' })
+  @IsOptional()
+  @IsString()
+  status?: string;
 }

--- a/backend/src/payment/application/use-cases/confirm-payment.use-case.ts
+++ b/backend/src/payment/application/use-cases/confirm-payment.use-case.ts
@@ -48,7 +48,11 @@ export class ConfirmPaymentUseCase {
     const payment = await this.paymentRepository.findByReference(reference);
     if (!payment) throw new NotFoundException('Pago no encontrado para esta referencia');
 
-    return this.processPayment(payment, 'APPROVED');
+    const realStatus = await this.wompiService.getTransactionStatus(
+      payment.wompi_transaction_id,
+    );
+
+    return this.processPayment(payment, realStatus);
   }
 
   private async processPayment(payment: any, newStatus: string): Promise<{ status: string }> {

--- a/backend/src/payment/application/use-cases/create-payment.use-case.ts
+++ b/backend/src/payment/application/use-cases/create-payment.use-case.ts
@@ -3,6 +3,7 @@ import { IPaymentRepository } from '../../domain/repositories/payment.repository
 import { IOrderRepository } from 'src/order/domain/repositories/order.repository.interface';
 import { WompiService } from '../../infrastructure/services/wompi.service';
 import { FastApiService } from 'src/shared/services/fastapi.service';
+import { RegisterVendorSaleUseCase } from 'src/liquidation/application/use-cases/register-vendor-sale.use-case';
 import { CreatePaymentDto } from '../dtos/create-payment.dto';
 import { PaymentModel } from '../../domain/entities/payment.model';
 import { randomUUID } from 'crypto';
@@ -16,6 +17,7 @@ export class CreatePaymentUseCase {
     private readonly orderRepository: IOrderRepository,
     private readonly wompiService: WompiService,
     private readonly fastApiService: FastApiService,
+    private readonly registerVendorSale: RegisterVendorSaleUseCase,
   ) {}
 
   async execute(dto: CreatePaymentDto, userId: number): Promise<PaymentModel> {
@@ -35,6 +37,7 @@ export class CreatePaymentUseCase {
     // Si ya viene un transaction_id del WidgetCheckout, saltar Wompi API
     if (dto.transaction_id) {
       const reference = dto.reference || `urbanrush-${dto.order_id}-${randomUUID()}`;
+      const initialStatus = dto.status || 'PENDING';
       const payment = new PaymentModel(
         null,
         dto.order_id,
@@ -43,14 +46,21 @@ export class CreatePaymentUseCase {
         dto.transaction_id,
         amountInCents,
         'COP',
-        'PENDING',
+        initialStatus,
         dto.payment_method.type ?? 'CARD',
         reference,
         dto.customer_email,
         null,
         null,
       );
-      return this.paymentRepository.create(payment);
+      const created = await this.paymentRepository.create(payment);
+
+      if (initialStatus === 'APPROVED') {
+        await this.orderRepository.updateStatus(dto.order_id, 'ACCEPTED');
+        await this.registerVendorSale.execute(dto.order_id);
+      }
+
+      return created;
     }
 
     // Análisis de fraude — bloquea si es sospechoso

--- a/backend/src/payment/infrastructure/services/wompi.service.ts
+++ b/backend/src/payment/infrastructure/services/wompi.service.ts
@@ -97,9 +97,15 @@ export class WompiService {
         `${this.baseUrl}/transactions/${transactionId}`,
         { headers: { Authorization: `Bearer ${this.privateKey}` } },
       );
-      return response.data.data.status;
-    } catch {
-      this.logger.warn(`No se pudo consultar transacción ${transactionId} en Wompi`);
+      const status = response.data.data.status;
+      this.logger.log(`Transacción ${transactionId} en Wompi: ${status}`);
+      return status;
+    } catch (error) {
+      if (axios.isAxiosError(error)) {
+        this.logger.warn(`Error consultando transacción ${transactionId}: ${error.response?.status} ${error.response?.data?.message ?? error.message}`);
+      } else {
+        this.logger.warn(`Error inesperado consultando transacción ${transactionId}: ${(error as Error).message}`);
+      }
       return 'PENDING';
     }
   }


### PR DESCRIPTION
## 🔴 Bug crítico de seguridad

`confirmByReference` hardcodeaba `'APPROVED'` sin verificar el estado real de la
transacción en Wompi. Cualquier pago (incluso rechazado) se marcaba como exitoso.

## Cambios

### Backend
- **`confirm-payment.use-case.ts`**: ahora llama a `wompiService.getTransactionStatus()`
  para obtener el estado real de Wompi, en vez de usar `'APPROVED'` fijo
- **`create-payment.dto.ts`**: agrega campo opcional `status`
- **`create-payment.use-case.ts`**: si el widget ya devuelve `APPROVED`, crea el payment
  con ese estado y actualiza la orden a `ACCEPTED` inmediatamente
- **`wompi.service.ts`**: logging detallado de respuestas de Wompi

### Frontend
- **`PaymentPage.tsx`**: widget callback verifica `result.transaction.status`
  - `APPROVED` → payment creado como aprobado, toast éxito
  - `DECLINED/ERROR/VOIDED` → no se crea payment, se muestra rechazo
  - Otro → flujo anterior (PENDING + polling)
- Polling reducido de **10s → 5s**
- **`payment.types.ts`**: agrega `status` a `CreatePaymentRequest`